### PR TITLE
feat(barcode): EAN/barcode lookup with shared cache and web entry

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -55,6 +55,7 @@ class Capabilities implements IPublicCapability {
 					'categories',
 					'category-sort',
 					'stores',
+					'barcode',
 					'photos',
 					'notes',
 					'note-pinning',

--- a/lib/Controller/BarcodeController.php
+++ b/lib/Controller/BarcodeController.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Controller;
+
+use OCA\Pantry\Db\BarcodeCache;
+use OCA\Pantry\Exception\NotFoundException;
+use OCA\Pantry\ResponseDefinitions;
+use OCA\Pantry\Service\BarcodeService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\ApiRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+
+/**
+ * @psalm-import-type PantryBarcode from ResponseDefinitions
+ */
+final class BarcodeController extends OCSController {
+	use TranslatesDomainExceptions;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private BarcodeService $barcodes,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Look up a barcode in the shared cache
+	 *
+	 * Cache-only: never makes an external call. A miss returns 404 so the
+	 * client resolves it from its own IP and writes the result back.
+	 *
+	 * @param string $ean Barcode digits (EAN/UPC).
+	 *
+	 * @return DataResponse<Http::STATUS_OK, PantryBarcode, array{}>
+	 *
+	 * 200: Barcode found in cache
+	 */
+	#[ApiRoute(verb: 'GET', url: '/api/barcode/{ean}', requirements: ['ean' => '\d+'])]
+	#[NoAdminRequired]
+	public function show(string $ean): DataResponse {
+		return $this->runAction(function () use ($ean): DataResponse {
+			$cached = $this->barcodes->getFromCache($ean);
+			if ($cached === null) {
+				throw new NotFoundException('Barcode not found');
+			}
+			return new DataResponse($this->serialize($cached));
+		});
+	}
+
+	/**
+	 * Write a resolved barcode back to the shared cache
+	 *
+	 * @param string $ean Barcode digits (EAN/UPC).
+	 * @param string $name Resolved product name.
+	 * @param string|null $brand Brand name.
+	 * @param string|null $category Provider category hint (for best-match).
+	 * @param string|null $imageUrl Product image URL.
+	 * @param string|null $provider Id of the source that resolved it.
+	 * @param string|null $raw Raw provider payload.
+	 *
+	 * @return DataResponse<Http::STATUS_OK, PantryBarcode, array{}>
+	 *
+	 * 200: Barcode cached
+	 */
+	#[ApiRoute(verb: 'POST', url: '/api/barcode')]
+	#[NoAdminRequired]
+	public function store(
+		string $ean,
+		string $name,
+		?string $brand = null,
+		?string $category = null,
+		?string $imageUrl = null,
+		?string $provider = null,
+		?string $raw = null,
+	): DataResponse {
+		return $this->runAction(function () use ($ean, $name, $brand, $category, $imageUrl, $provider, $raw): DataResponse {
+			$cached = $this->barcodes->saveResult([
+				'ean' => $ean,
+				'name' => $name,
+				'brand' => $brand,
+				'category' => $category,
+				'imageUrl' => $imageUrl,
+				'provider' => $provider,
+				'raw' => $raw,
+			]);
+			return new DataResponse($this->serialize($cached));
+		});
+	}
+
+	/**
+	 * @return PantryBarcode
+	 */
+	private function serialize(BarcodeCache $cache): array {
+		return [
+			'ean' => $cache->getEan(),
+			'name' => $cache->getName(),
+			'brand' => $cache->getBrand(),
+			'category' => $cache->getCategory(),
+			'imageUrl' => $cache->getImageUrl(),
+			'provider' => $cache->getProvider(),
+		];
+	}
+}

--- a/lib/Controller/ChecklistController.php
+++ b/lib/Controller/ChecklistController.php
@@ -557,6 +557,7 @@ final class ChecklistController extends OCSController {
 	 * @param bool $deleteOnDone If true, the item is deleted when marked done.
 	 * @param int|null $sortOrder Optional sort order.
 	 * @param list<int> $storeIds Optional store ids to attach (must belong to the same house).
+	 * @param string|null $barcode Optional barcode (EAN/UPC) the item was created from.
 	 *
 	 * @return DataResponse<Http::STATUS_OK, PantryListItem, array{}>
 	 *
@@ -577,8 +578,9 @@ final class ChecklistController extends OCSController {
 		bool $deleteOnDone = false,
 		?int $sortOrder = null,
 		array $storeIds = [],
+		?string $barcode = null,
 	): DataResponse {
-		return $this->runAction(function () use ($houseId, $listId, $name, $description, $categoryId, $quantity, $rrule, $repeatFromCompletion, $deleteOnDone, $sortOrder, $storeIds): DataResponse {
+		return $this->runAction(function () use ($houseId, $listId, $name, $description, $categoryId, $quantity, $rrule, $repeatFromCompletion, $deleteOnDone, $sortOrder, $storeIds, $barcode): DataResponse {
 			$uid = $this->requireUid();
 			$this->auth->requireMember($houseId, $uid);
 			$list = $this->lists->getList($listId);
@@ -598,6 +600,7 @@ final class ChecklistController extends OCSController {
 				'deleteOnDone' => $deleteOnDone,
 				'sortOrder' => $sortOrder ?? 0,
 				'storeIds' => $storeIds,
+				'barcode' => $barcode,
 			], $uid);
 			$this->notifications->notifyItemAdded($houseId, $uid, $item->getName(), $list->getName());
 			$this->activity->publishItemAdded(
@@ -630,6 +633,7 @@ final class ChecklistController extends OCSController {
 	 * @param int|null $sortOrder New sort order.
 	 * @param int|null $targetListId Move item to a different list (must belong to the same house).
 	 * @param list<int>|null $storeIds New set of store ids (empty array clears; null leaves unchanged). All must belong to the same house.
+	 * @param string|null $barcode New barcode (EAN/UPC); empty string clears.
 	 *
 	 * @return DataResponse<Http::STATUS_OK, PantryListItem, array{}>
 	 *
@@ -653,8 +657,9 @@ final class ChecklistController extends OCSController {
 		?int $sortOrder = null,
 		?int $targetListId = null,
 		?array $storeIds = null,
+		?string $barcode = null,
 	): DataResponse {
-		return $this->runAction(function () use ($houseId, $listId, $itemId, $name, $description, $categoryId, $quantity, $rrule, $repeatFromCompletion, $deleteOnDone, $imageFileId, $sortOrder, $targetListId, $storeIds): DataResponse {
+		return $this->runAction(function () use ($houseId, $listId, $itemId, $name, $description, $categoryId, $quantity, $rrule, $repeatFromCompletion, $deleteOnDone, $imageFileId, $sortOrder, $targetListId, $storeIds, $barcode): DataResponse {
 			$uid = $this->requireUid();
 			$this->auth->requireMember($houseId, $uid);
 			$item = $this->lists->getItem($itemId);
@@ -695,6 +700,9 @@ final class ChecklistController extends OCSController {
 			}
 			if ($sortOrder !== null) {
 				$patch['sortOrder'] = $sortOrder;
+			}
+			if ($barcode !== null) {
+				$patch['barcode'] = $barcode;
 			}
 			if ($storeIds !== null) {
 				$ids = array_map('intval', $storeIds);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -8,6 +8,7 @@ use OCA\Pantry\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -31,10 +32,17 @@ class PageController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function index(): TemplateResponse {
-		return new TemplateResponse(Application::APP_ID, 'app', [
+		$response = new TemplateResponse(Application::APP_ID, 'app', [
 			'script' => Application::getViteEntryScript('app.ts'),
 			'style' => Application::getViteEntryScript('style.css'),
 		]);
+		// Allow the barcode-scanner wasm fallback (Firefox/Safari, which lack a
+		// native BarcodeDetector) to execute. The wasm is served from the app
+		// origin, so no extra domains are needed — only 'wasm-unsafe-eval'.
+		$csp = new ContentSecurityPolicy();
+		$csp->allowEvalWasm(true);
+		$response->setContentSecurityPolicy($csp);
+		return $response;
 	}
 
 	/**

--- a/lib/Db/BarcodeCache.php
+++ b/lib/Db/BarcodeCache.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method string getEan()
+ * @method void setEan(string $ean)
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method string|null getBrand()
+ * @method void setBrand(?string $brand)
+ * @method string|null getCategory()
+ * @method void setCategory(?string $category)
+ * @method string|null getImageUrl()
+ * @method void setImageUrl(?string $imageUrl)
+ * @method string getProvider()
+ * @method void setProvider(string $provider)
+ * @method string|null getRaw()
+ * @method void setRaw(?string $raw)
+ * @method int getResolvedAt()
+ * @method void setResolvedAt(int $resolvedAt)
+ */
+class BarcodeCache extends Entity implements \JsonSerializable {
+	protected string $ean = '';
+	protected string $name = '';
+	protected ?string $brand = null;
+	protected ?string $category = null;
+	protected ?string $imageUrl = null;
+	protected string $provider = '';
+	protected ?string $raw = null;
+	protected int $resolvedAt = 0;
+
+	public function __construct() {
+		$this->addType('resolvedAt', 'integer');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->id,
+			'ean' => $this->ean,
+			'name' => $this->name,
+			'brand' => $this->brand,
+			'category' => $this->category,
+			'imageUrl' => $this->imageUrl,
+			'provider' => $this->provider,
+			'resolvedAt' => $this->resolvedAt,
+		];
+	}
+}

--- a/lib/Db/BarcodeCacheMapper.php
+++ b/lib/Db/BarcodeCacheMapper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Db;
+
+use OCA\Pantry\AppInfo\Application;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<BarcodeCache>
+ */
+class BarcodeCacheMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, Application::tableName('barcode_cache'), BarcodeCache::class);
+	}
+
+	public function findByEan(string $ean): ?BarcodeCache {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('ean', $qb->createNamedParameter($ean, IQueryBuilder::PARAM_STR)));
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+}

--- a/lib/Db/ChecklistItem.php
+++ b/lib/Db/ChecklistItem.php
@@ -40,6 +40,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setImageUploadedBy(?string $imageUploadedBy)
  * @method string|null getAddedBy()
  * @method void setAddedBy(?string $addedBy)
+ * @method string|null getBarcode()
+ * @method void setBarcode(?string $barcode)
  * @method int getSortOrder()
  * @method void setSortOrder(int $sortOrder)
  * @method int getCreatedAt()
@@ -67,6 +69,7 @@ class ChecklistItem extends Entity implements \JsonSerializable {
 	protected ?int $imageFileId = null;
 	protected ?string $imageUploadedBy = null;
 	protected ?string $addedBy = null;
+	protected ?string $barcode = null;
 	protected int $sortOrder = 0;
 	protected int $createdAt = 0;
 	protected int $updatedAt = 0;
@@ -114,6 +117,7 @@ class ChecklistItem extends Entity implements \JsonSerializable {
 			'imageFileId' => $this->imageFileId,
 			'imageUploadedBy' => $this->imageUploadedBy,
 			'addedBy' => $this->addedBy,
+			'barcode' => $this->barcode,
 			'sortOrder' => $this->sortOrder,
 			'createdAt' => $this->createdAt,
 			'updatedAt' => $this->updatedAt,

--- a/lib/Migration/Version18Date20260729000000.php
+++ b/lib/Migration/Version18Date20260729000000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Migration;
+
+use Closure;
+use OCA\Pantry\AppInfo\Application;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Barcode (EAN/UPC) lookup support.
+ *
+ * - pantry_barcode_cache: global, shared cache of resolved barcodes. Not
+ *   house-scoped — barcodes are universal, so one resolution serves every house.
+ * - pantry_list_items.barcode: the barcode a checklist item was created from.
+ */
+class Version18Date20260729000000 extends SimpleMigrationStep {
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$cacheTable = Application::tableName('barcode_cache');
+		if (!$schema->hasTable($cacheTable)) {
+			$table = $schema->createTable($cacheTable);
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('ean', Types::STRING, ['notnull' => true, 'length' => 64]);
+			$table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 512]);
+			$table->addColumn('brand', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+			$table->addColumn('category', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+			$table->addColumn('image_url', Types::STRING, ['notnull' => false, 'length' => 1024, 'default' => null]);
+			$table->addColumn('provider', Types::STRING, ['notnull' => true, 'length' => 64]);
+			$table->addColumn('raw', Types::TEXT, ['notnull' => false, 'default' => null]);
+			$table->addColumn('resolved_at', Types::BIGINT, ['notnull' => true]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['ean'], 'pantry_barcode_ean_uq');
+		}
+
+		$itemsTable = Application::tableName('list_items');
+		if ($schema->hasTable($itemsTable)) {
+			$table = $schema->getTable($itemsTable);
+			if (!$table->hasColumn('barcode')) {
+				$table->addColumn('barcode', Types::STRING, [
+					'notnull' => false,
+					'length' => 64,
+					'default' => null,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -92,6 +92,7 @@ namespace OCA\Pantry;
  *     imageFileId: int|null,
  *     imageUploadedBy: string|null,
  *     addedBy: string|null,
+ *     barcode: string|null,
  *     sortOrder: int,
  *     createdAt: int,
  *     updatedAt: int,
@@ -150,6 +151,15 @@ namespace OCA\Pantry;
  *     createdBy: string,
  *     createdAt: int,
  *     updatedAt: int,
+ * }
+ *
+ * @psalm-type PantryBarcode = array{
+ *     ean: string,
+ *     name: string,
+ *     brand: string|null,
+ *     category: string|null,
+ *     imageUrl: string|null,
+ *     provider: string,
  * }
  *
  * @psalm-type PantrySuccess = array{success: true}

--- a/lib/Service/Barcode/BarcodeLookupProvider.php
+++ b/lib/Service/Barcode/BarcodeLookupProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Service\Barcode;
+
+/**
+ * A source that can resolve a barcode (EAN/UPC) into product details.
+ *
+ * Providers are keyed by {@see self::getId()} and selected via the
+ * `barcode_provider` app config value. This is the server-side lookup path
+ * (used by the deferred proxy endpoint); the default client-side path resolves
+ * from the user's own IP and writes the result back.
+ */
+interface BarcodeLookupProvider {
+	/**
+	 * Stable identifier, e.g. "openfoodfacts". Stored on cached rows.
+	 */
+	public function getId(): string;
+
+	/**
+	 * Resolve a barcode, or return null when the product is unknown or the
+	 * lookup fails. Must never throw for a plain "not found".
+	 */
+	public function lookup(string $ean): ?BarcodeResult;
+}

--- a/lib/Service/Barcode/BarcodeResult.php
+++ b/lib/Service/Barcode/BarcodeResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Service\Barcode;
+
+/**
+ * Immutable result of resolving a barcode, independent of the provider that
+ * produced it.
+ */
+class BarcodeResult {
+	public function __construct(
+		public readonly string $ean,
+		public readonly string $name,
+		public readonly ?string $brand,
+		public readonly ?string $category,
+		public readonly ?string $imageUrl,
+		public readonly string $provider,
+		public readonly ?string $raw = null,
+	) {
+	}
+
+	/**
+	 * @return array{ean: string, name: string, brand: string|null, category: string|null, imageUrl: string|null, provider: string}
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'ean' => $this->ean,
+			'name' => $this->name,
+			'brand' => $this->brand,
+			'category' => $this->category,
+			'imageUrl' => $this->imageUrl,
+			'provider' => $this->provider,
+		];
+	}
+}

--- a/lib/Service/Barcode/OpenFoodFactsProvider.php
+++ b/lib/Service/Barcode/OpenFoodFactsProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Service\Barcode;
+
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves barcodes against the free Open Food Facts database.
+ *
+ * No API key required; the API asks only for a descriptive User-Agent.
+ * @see https://openfoodfacts.github.io/openfoodfacts-server/api/
+ */
+class OpenFoodFactsProvider implements BarcodeLookupProvider {
+	public const ID = 'openfoodfacts';
+
+	private const ENDPOINT = 'https://world.openfoodfacts.org/api/v2/product/%s.json';
+	private const USER_AGENT = 'NextcloudPantry - https://github.com/chenasraf/nextcloud-pantry';
+
+	public function __construct(
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getId(): string {
+		return self::ID;
+	}
+
+	public function lookup(string $ean): ?BarcodeResult {
+		$url = sprintf(self::ENDPOINT, rawurlencode($ean));
+		try {
+			$response = $this->clientService->newClient()->get($url, [
+				'headers' => ['User-Agent' => self::USER_AGENT],
+				'timeout' => 10,
+			]);
+		} catch (\Throwable $e) {
+			$this->logger->info('Open Food Facts lookup failed for {ean}: {message}', [
+				'ean' => $ean,
+				'message' => $e->getMessage(),
+				'app' => 'pantry',
+			]);
+			return null;
+		}
+
+		$body = json_decode((string)$response->getBody(), true);
+		if (!is_array($body) || (int)($body['status'] ?? 0) !== 1 || !is_array($body['product'] ?? null)) {
+			// status 0 => product not found.
+			return null;
+		}
+
+		/** @var array<string, mixed> $product */
+		$product = $body['product'];
+		$name = $this->pickName($product);
+		if ($name === null) {
+			// A row with no usable name is not worth caching.
+			return null;
+		}
+
+		$raw = json_encode($product);
+		return new BarcodeResult(
+			ean: $ean,
+			name: $name,
+			brand: $this->firstOf((string)($product['brands'] ?? '')),
+			category: $this->firstOf((string)($product['categories'] ?? '')),
+			imageUrl: $this->strOrNull($product['image_url'] ?? null),
+			provider: self::ID,
+			raw: $raw === false ? null : $raw,
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $product
+	 */
+	private function pickName(array $product): ?string {
+		foreach (['product_name', 'generic_name', 'abbreviated_product_name'] as $key) {
+			$value = $this->strOrNull($product[$key] ?? null);
+			if ($value !== null) {
+				return $value;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Open Food Facts returns comma-separated lists for brands/categories.
+	 * Keep the first entry, which is the most specific/primary one.
+	 */
+	private function firstOf(string $csv): ?string {
+		$first = trim(explode(',', $csv)[0] ?? '');
+		return $first === '' ? null : $first;
+	}
+
+	private function strOrNull(mixed $value): ?string {
+		if (!is_string($value)) {
+			return null;
+		}
+		$value = trim($value);
+		return $value === '' ? null : $value;
+	}
+}

--- a/lib/Service/BarcodeService.php
+++ b/lib/Service/BarcodeService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Service;
+
+use OCA\Pantry\Db\BarcodeCache;
+use OCA\Pantry\Db\BarcodeCacheMapper;
+use OCA\Pantry\Service\Barcode\BarcodeLookupProvider;
+use OCA\Pantry\Service\Barcode\BarcodeResult;
+use OCA\Pantry\Service\Barcode\OpenFoodFactsProvider;
+use OCP\IAppConfig;
+
+class BarcodeService {
+	/** @var array<string, BarcodeLookupProvider> */
+	private array $providers;
+
+	public function __construct(
+		private BarcodeCacheMapper $mapper,
+		private IAppConfig $appConfig,
+		OpenFoodFactsProvider $openFoodFacts,
+	) {
+		// Register available providers by id. Add new providers here.
+		$this->providers = [$openFoodFacts->getId() => $openFoodFacts];
+	}
+
+	/**
+	 * Shared-cache lookup only — never makes an external call. This is the
+	 * common "do you know EAN X?" path.
+	 */
+	public function getFromCache(string $ean): ?BarcodeCache {
+		return $this->mapper->findByEan($this->normalizeEan($ean));
+	}
+
+	/**
+	 * Persist a resolved barcode into the shared cache (upsert). Used for
+	 * client write-back and by the server-side proxy path.
+	 *
+	 * @param array{ean?: mixed, name?: mixed, brand?: mixed, category?: mixed, imageUrl?: mixed, provider?: mixed, raw?: mixed} $data
+	 */
+	public function saveResult(array $data): BarcodeCache {
+		$ean = $this->normalizeEan((string)($data['ean'] ?? ''));
+		$name = trim((string)($data['name'] ?? ''));
+		if ($name === '') {
+			throw new \InvalidArgumentException('Barcode name cannot be empty');
+		}
+
+		$existing = $this->mapper->findByEan($ean);
+		$entity = $existing ?? new BarcodeCache();
+		$entity->setEan($ean);
+		$entity->setName($name);
+		$entity->setBrand($this->strOrNull($data['brand'] ?? null));
+		$entity->setCategory($this->strOrNull($data['category'] ?? null));
+		$entity->setImageUrl($this->strOrNull($data['imageUrl'] ?? null));
+		$entity->setProvider($this->strOrNull($data['provider'] ?? null) ?? 'client');
+		$entity->setRaw($this->strOrNull($data['raw'] ?? null));
+		$entity->setResolvedAt(time());
+
+		/** @var BarcodeCache $saved */
+		$saved = $existing !== null ? $this->mapper->update($entity) : $this->mapper->insert($entity);
+		return $saved;
+	}
+
+	/**
+	 * Server-side resolution via the configured provider. Only used by the
+	 * deferred proxy endpoint — the default path resolves client-side.
+	 */
+	public function resolveViaProvider(string $ean): ?BarcodeResult {
+		return $this->provider()->lookup($this->normalizeEan($ean));
+	}
+
+	private function provider(): BarcodeLookupProvider {
+		$id = $this->appConfig->getValueString('pantry', 'barcode_provider', OpenFoodFactsProvider::ID);
+		return $this->providers[$id] ?? $this->providers[OpenFoodFactsProvider::ID];
+	}
+
+	private function normalizeEan(string $ean): string {
+		$ean = trim($ean);
+		if (!preg_match('/^\d{6,14}$/', $ean)) {
+			throw new \InvalidArgumentException('Invalid barcode');
+		}
+		return $ean;
+	}
+
+	private function strOrNull(mixed $value): ?string {
+		if (!is_string($value)) {
+			return null;
+		}
+		$value = trim($value);
+		return $value === '' ? null : $value;
+	}
+}

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -259,6 +259,7 @@ class ChecklistService {
 		}
 		$item->setImageFileId($this->intOrNull($data['imageFileId'] ?? null));
 		$item->setAddedBy($addedBy);
+		$item->setBarcode($this->strOrNull($data['barcode'] ?? null));
 		$item->setSortOrder(isset($data['sortOrder']) ? (int)$data['sortOrder'] : 0);
 		$item->setCreatedAt($now);
 		$item->setUpdatedAt($now);
@@ -311,6 +312,9 @@ class ChecklistService {
 		}
 		if (array_key_exists('imageFileId', $patch)) {
 			$item->setImageFileId($this->intOrNull($patch['imageFileId']));
+		}
+		if (array_key_exists('barcode', $patch)) {
+			$item->setBarcode($this->strOrNull($patch['barcode']));
 		}
 		if (array_key_exists('imageUploadedBy', $patch)) {
 			$v = $patch['imageUploadedBy'];

--- a/openapi.json
+++ b/openapi.json
@@ -20,6 +20,40 @@
             }
         },
         "schemas": {
+            "Barcode": {
+                "type": "object",
+                "required": [
+                    "ean",
+                    "name",
+                    "brand",
+                    "category",
+                    "imageUrl",
+                    "provider"
+                ],
+                "properties": {
+                    "ean": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "brand": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "category": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "provider": {
+                        "type": "string"
+                    }
+                }
+            },
             "BatchResult": {
                 "type": "object",
                 "required": [
@@ -441,6 +475,7 @@
                     "imageFileId",
                     "imageUploadedBy",
                     "addedBy",
+                    "barcode",
                     "sortOrder",
                     "createdAt",
                     "updatedAt",
@@ -516,6 +551,10 @@
                         "nullable": true
                     },
                     "addedBy": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "barcode": {
                         "type": "string",
                         "nullable": true
                     },
@@ -1204,6 +1243,249 @@
         }
     },
     "paths": {
+        "/ocs/v2.php/apps/pantry/api/barcode/{ean}": {
+            "get": {
+                "operationId": "barcode-show",
+                "summary": "Look up a barcode in the shared cache",
+                "description": "Cache-only: never makes an external call. A miss returns 404 so the client resolves it from its own IP and writes the result back.",
+                "tags": [
+                    "barcode"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "ean",
+                        "in": "path",
+                        "description": "Barcode digits (EAN/UPC).",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^\\d+$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Barcode found in cache",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Barcode"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/pantry/api/barcode": {
+            "post": {
+                "operationId": "barcode-store",
+                "summary": "Write a resolved barcode back to the shared cache",
+                "tags": [
+                    "barcode"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "ean",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "ean": {
+                                        "type": "string",
+                                        "description": "Barcode digits (EAN/UPC)."
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Resolved product name."
+                                    },
+                                    "brand": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Brand name."
+                                    },
+                                    "category": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Provider category hint (for best-match)."
+                                    },
+                                    "imageUrl": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Product image URL."
+                                    },
+                                    "provider": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Id of the source that resolved it."
+                                    },
+                                    "raw": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Raw provider payload."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Barcode cached",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Barcode"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/pantry/api/houses/{houseId}/categories": {
             "get": {
                 "operationId": "category-index",
@@ -3414,6 +3696,12 @@
                                             "type": "integer",
                                             "format": "int64"
                                         }
+                                    },
+                                    "barcode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Optional barcode (EAN/UPC) the item was created from."
                                     }
                                 }
                             }
@@ -3988,6 +4276,12 @@
                                             "type": "integer",
                                             "format": "int64"
                                         }
+                                    },
+                                    "barcode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "New barcode (EAN/UPC); empty string clears."
                                     }
                                 }
                             }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/vite-config": "^2.5.4",
     "@nextcloud/vue": "^9.9.0",
+    "barcode-detector": "^3.2.1",
     "date-fns": "^4.4.0",
     "fuzzball": "^2.2.6",
     "linkifyjs": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nextcloud/vue':
         specifier: ^9.9.0
         version: 9.9.0(@vue/compiler-sfc@3.5.40)(esbuild@0.27.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(sass-embedded@1.100.0)(sass@1.102.0)(yaml@2.9.0))
+      barcode-detector:
+        specifier: ^3.2.1
+        version: 3.2.1(@types/emscripten@1.41.5)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1194,6 +1197,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/escape-html@1.0.4':
     resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
@@ -1598,6 +1604,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.2.1:
+    resolution: {integrity: sha512-zLL7AbT9uNJBUzYpKg9v5tUA4yQGReExSi60q0g660Mj0wjUhKmN0GrUF3qELo8ITW9THzyJXdZQkXLMnsieiw==}
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
@@ -3886,6 +3895,10 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
@@ -3951,6 +3964,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4379,6 +4396,11 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  zxing-wasm@3.1.1:
+    resolution: {integrity: sha512-g0sPJBIubO6zLcJh1jftLPIN6xziaqLsvLgtpGKwDrEhyXXqla3E3yjFrznlr78UHIOMzbJPi0HDWKs/KgaB7A==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -5350,6 +5372,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/escape-html@1.0.4': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -5823,6 +5847,12 @@ snapshots:
   balanced-match@2.0.0: {}
 
   balanced-match@4.0.4: {}
+
+  barcode-detector@3.2.1(@types/emscripten@1.41.5):
+    dependencies:
+      zxing-wasm: 3.1.1(@types/emscripten@1.41.5)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   base-64@1.0.0: {}
 
@@ -8408,6 +8438,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tagged-tag@1.0.0: {}
+
   timers-browserify@2.0.12:
     dependencies:
       setimmediate: 1.0.5
@@ -8461,6 +8493,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -8864,3 +8900,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zwitch@2.0.4: {}
+
+  zxing-wasm@3.1.1(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.8.0

--- a/src/api/barcode.test.ts
+++ b/src/api/barcode.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { get, post } = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('@/axios', () => ({ ocs: { get, post } }))
+
+import { lookupBarcode, resolveExternally, saveBarcode } from './barcode'
+
+describe('lookupBarcode', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('returns the cached result on a hit', async () => {
+    const result = {
+      ean: '4001724819103',
+      name: 'Cola',
+      brand: 'Acme',
+      category: 'Beverages',
+      imageUrl: null,
+      provider: 'openfoodfacts',
+    }
+    get.mockResolvedValueOnce({ data: result })
+
+    expect(await lookupBarcode('4001724819103')).toEqual(result)
+    expect(get).toHaveBeenCalledWith('/barcode/4001724819103')
+  })
+
+  it('returns null on a 404 cache miss', async () => {
+    get.mockRejectedValueOnce({ response: { status: 404 } })
+    expect(await lookupBarcode('4001724819103')).toBeNull()
+  })
+
+  it('rethrows non-404 errors', async () => {
+    get.mockRejectedValueOnce({ response: { status: 500 } })
+    await expect(lookupBarcode('4001724819103')).rejects.toEqual({ response: { status: 500 } })
+  })
+})
+
+describe('saveBarcode', () => {
+  beforeEach(() => post.mockReset())
+
+  it('posts the write-back payload', async () => {
+    const result = {
+      ean: '4001724819103',
+      name: 'Cola',
+      brand: 'Acme',
+      category: 'Beverages',
+      imageUrl: 'https://img/x.jpg',
+      provider: 'openfoodfacts',
+    }
+    post.mockResolvedValueOnce({ data: result })
+
+    await saveBarcode(result)
+    expect(post).toHaveBeenCalledWith('/barcode', {
+      ean: '4001724819103',
+      name: 'Cola',
+      brand: 'Acme',
+      category: 'Beverages',
+      imageUrl: 'https://img/x.jpg',
+      provider: 'openfoodfacts',
+    })
+  })
+})
+
+describe('resolveExternally', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  function mockFetch(status: number, body: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        json: () => Promise.resolve(body),
+      }),
+    )
+  }
+
+  it('maps Open Food Facts fields, keeping the primary brand/category', async () => {
+    mockFetch(200, {
+      status: 1,
+      product: {
+        product_name: 'Cola Zero',
+        brands: 'Acme, SubBrand',
+        categories: 'Beverages, Sodas',
+        image_url: 'https://images/x.jpg',
+      },
+    })
+
+    const result = await resolveExternally('4001724819103')
+    expect(result).toEqual({
+      ean: '4001724819103',
+      name: 'Cola Zero',
+      brand: 'Acme',
+      category: 'Beverages',
+      imageUrl: 'https://images/x.jpg',
+      provider: 'openfoodfacts',
+    })
+  })
+
+  it('returns null when the product is not found', async () => {
+    mockFetch(200, { status: 0 })
+    expect(await resolveExternally('0000000000000')).toBeNull()
+  })
+
+  it('returns null when the product has no usable name', async () => {
+    mockFetch(200, { status: 1, product: { brands: 'Acme' } })
+    expect(await resolveExternally('4001724819103')).toBeNull()
+  })
+
+  it('returns null on a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await resolveExternally('4001724819103')).toBeNull()
+  })
+})

--- a/src/api/barcode.ts
+++ b/src/api/barcode.ts
@@ -1,0 +1,125 @@
+import { ocs } from '../axios'
+
+/**
+ * A resolved barcode, matching the backend `PantryBarcode` shape.
+ */
+export interface BarcodeResult {
+  ean: string
+  name: string
+  brand: string | null
+  /** Provider category hint, used for best-match against house categories. */
+  category: string | null
+  imageUrl: string | null
+  provider: string
+}
+
+/**
+ * Ask the backend whether a barcode is already in the shared cache.
+ * Returns the cached result, or null on a cache miss (404).
+ */
+export async function lookupBarcode(ean: string): Promise<BarcodeResult | null> {
+  try {
+    const resp = await ocs.get<BarcodeResult>(`/barcode/${encodeURIComponent(ean)}`)
+    return resp.data
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      return null
+    }
+    throw err
+  }
+}
+
+/**
+ * Write a client-resolved barcode back to the shared cache so it becomes an
+ * instant hit for the whole house next time.
+ */
+export async function saveBarcode(result: BarcodeResult): Promise<BarcodeResult> {
+  const resp = await ocs.post<BarcodeResult>('/barcode', {
+    ean: result.ean,
+    name: result.name,
+    brand: result.brand ?? undefined,
+    category: result.category ?? undefined,
+    imageUrl: result.imageUrl ?? undefined,
+    provider: result.provider,
+  })
+  return resp.data
+}
+
+/**
+ * Resolve a barcode against the external provider from the user's own IP
+ * (Open Food Facts, open CORS, no key). Uses native fetch — never the
+ * Nextcloud axios instance — so no CSRF/session headers leak to a third party.
+ *
+ * v1 ships Open Food Facts only; a future provider swap lives here.
+ */
+export async function resolveExternally(ean: string): Promise<BarcodeResult | null> {
+  const url = `https://world.openfoodfacts.org/api/v2/product/${encodeURIComponent(ean)}.json`
+  let body: OffResponse
+  try {
+    const resp = await fetch(url, { headers: { Accept: 'application/json' } })
+    if (!resp.ok) {
+      return null
+    }
+    body = (await resp.json()) as OffResponse
+  } catch {
+    return null
+  }
+
+  if (body.status !== 1 || !body.product) {
+    return null
+  }
+  const p = body.product
+  const name = firstNonEmpty(p.product_name, p.generic_name, p.abbreviated_product_name)
+  if (!name) {
+    return null
+  }
+  return {
+    ean,
+    name,
+    brand: firstOf(p.brands),
+    category: firstOf(p.categories),
+    imageUrl: strOrNull(p.image_url),
+    provider: 'openfoodfacts',
+  }
+}
+
+interface OffResponse {
+  status?: number
+  product?: {
+    product_name?: string
+    generic_name?: string
+    abbreviated_product_name?: string
+    brands?: string
+    categories?: string
+    image_url?: string
+  }
+}
+
+/** Open Food Facts returns comma-separated lists; keep the primary entry. */
+function firstOf(csv: string | undefined): string | null {
+  return firstNonEmpty((csv ?? '').split(',')[0])
+}
+
+function firstNonEmpty(...values: (string | undefined)[]): string | null {
+  for (const value of values) {
+    const trimmed = (value ?? '').trim()
+    if (trimmed !== '') {
+      return trimmed
+    }
+  }
+  return null
+}
+
+function strOrNull(value: string | undefined): string | null {
+  const trimmed = (value ?? '').trim()
+  return trimmed === '' ? null : trimmed
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'response' in err &&
+    (err as { response?: { status?: number } }).response?.status === 404
+  )
+}

--- a/src/api/lists.ts
+++ b/src/api/lists.ts
@@ -127,6 +127,7 @@ export interface ItemInput {
   deleteOnDone?: boolean
   sortOrder?: number
   targetListId?: number
+  barcode?: string | null
 }
 
 export async function addItem(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -130,6 +130,7 @@ export interface ChecklistItem {
   imageFileId: number | null
   imageUploadedBy: string | null
   addedBy: string | null
+  barcode: string | null
   sortOrder: number
   createdAt: number
   updatedAt: number

--- a/src/components/BarcodeLookupDialog/BarcodeLookupDialog.vue
+++ b/src/components/BarcodeLookupDialog/BarcodeLookupDialog.vue
@@ -1,0 +1,344 @@
+<template>
+  <NcDialog
+    :name="strings.title"
+    :open="open"
+    size="normal"
+    close-on-click-outside
+    @update:open="$emit('update:open', $event)"
+  >
+    <form class="pantry-barcode-form" autocomplete="off" @submit.prevent="submit">
+      <p class="pantry-barcode-form__hint">{{ strings.hint }}</p>
+      <!-- eslint-disable-next-line vue/no-v-html -- trusted, static link markup from t() -->
+      <p class="pantry-barcode-form__disclaimer" v-html="strings.disclaimer"></p>
+
+      <div v-if="scanning" class="pantry-barcode-form__scanner">
+        <video ref="videoRef" class="pantry-barcode-form__video" muted playsinline></video>
+        <NcButton class="pantry-barcode-form__scan-stop" @click="stopScan">
+          <template #icon>
+            <CloseIcon :size="20" />
+          </template>
+          {{ strings.stopScan }}
+        </NcButton>
+      </div>
+
+      <div v-else class="pantry-barcode-form__entry">
+        <NcTextField
+          v-model="value"
+          class="pantry-barcode-form__field"
+          :label="strings.eanLabel"
+          :placeholder="strings.eanPlaceholder"
+          inputmode="numeric"
+          autocomplete="off"
+          :error="!!error"
+          :helper-text="error ?? ''"
+        />
+        <NcButton
+          v-if="scanSupported"
+          class="pantry-barcode-form__scan-start"
+          :aria-label="strings.scan"
+          :title="strings.scan"
+          @click="startScan"
+        >
+          <template #icon>
+            <BarcodeScanIcon :size="20" />
+          </template>
+          {{ strings.scan }}
+        </NcButton>
+      </div>
+
+      <p v-if="scanError" class="pantry-barcode-form__error">{{ scanError }}</p>
+    </form>
+    <template #actions>
+      <NcButton @click="$emit('update:open', false)">{{ strings.cancel }}</NcButton>
+      <NcButton variant="primary" :disabled="loading || scanning || !isValid" @click="submit">
+        {{ loading ? strings.looking : strings.lookUp }}
+      </NcButton>
+    </template>
+  </NcDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { t } from '@nextcloud/l10n'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import BarcodeScanIcon from '@icons/BarcodeScan.vue'
+import CloseIcon from '@icons/Close.vue'
+import { lookupBarcode, resolveExternally, saveBarcode, type BarcodeResult } from '@/api/barcode'
+// The zxing reader wasm, emitted as a local app asset (hashed URL). Used only as
+// the ponyfill fallback for browsers without a native BarcodeDetector
+// (Firefox/Safari). Serving it from the app origin — rather than the package's
+// default jsDelivr CDN — keeps it within Nextcloud's CSP.
+import zxingReaderWasmUrl from 'virtual:zxing-reader-wasm-url'
+
+// Minimal structural type covering both the native BarcodeDetector and the
+// barcode-detector ponyfill.
+type BarcodeDetectorInstance = {
+  detect: (source: CanvasImageSource) => Promise<{ rawValue: string }[]>
+}
+type BarcodeDetectorCtor = new (opts: { formats: string[] }) => BarcodeDetectorInstance
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  /** ean is always the entered code; result is null when the product is unknown. */
+  resolved: [ean: string, result: BarcodeResult | null]
+}>()
+
+const value = ref('')
+const error = ref<string | null>(null)
+const loading = ref(false)
+
+// ----- Camera scanning -----
+const scanning = ref(false)
+const scanError = ref<string | null>(null)
+const videoRef = ref<HTMLVideoElement | null>(null)
+// Scanning needs a camera API. The decoder is the browser's native
+// BarcodeDetector when available (Chrome/Edge/Android — no wasm), otherwise the
+// zxing wasm ponyfill served locally (Firefox/Safari). The app relaxes its CSP
+// with allowEvalWasm() so the wasm can execute.
+const scanSupported = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
+
+// Non-reactive handles for the live scan session.
+let stream: MediaStream | null = null
+let scanTimer: ReturnType<typeof setInterval> | null = null
+let detecting = false
+
+const isValid = computed(() => /^\d{6,14}$/.test(value.value.trim()))
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      value.value = ''
+      error.value = null
+      scanError.value = null
+      loading.value = false
+    } else {
+      stopScan()
+    }
+  },
+)
+
+onBeforeUnmount(stopScan)
+
+async function startScan() {
+  scanError.value = null
+  scanning.value = true
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: 'environment' },
+      audio: false,
+    })
+    // Wait a tick for the <video> to render, then attach the stream.
+    await nextFrame()
+    const video = videoRef.value
+    if (!video) {
+      throw new Error('video element unavailable')
+    }
+    video.srcObject = stream
+    await video.play()
+
+    // Prefer the browser's native BarcodeDetector (no wasm). Fall back to the
+    // zxing ponyfill, lazy-loaded and pointed at the locally-served wasm.
+    const native = (window as unknown as { BarcodeDetector?: BarcodeDetectorCtor }).BarcodeDetector
+    let DetectorCtor: BarcodeDetectorCtor
+    if (native) {
+      DetectorCtor = native
+    } else {
+      const mod = await import('barcode-detector/ponyfill')
+      mod.setZXingModuleOverrides({
+        locateFile: (filePath: string, prefix: string) =>
+          filePath.endsWith('.wasm') ? zxingReaderWasmUrl : prefix + filePath,
+      })
+      DetectorCtor = mod.BarcodeDetector as unknown as BarcodeDetectorCtor
+    }
+    const detector = new DetectorCtor({
+      formats: ['ean_13', 'ean_8', 'upc_a', 'upc_e'],
+    })
+
+    scanTimer = setInterval(() => void detectFrame(detector, video), 350)
+  } catch (err: unknown) {
+    scanError.value = errorToMessage(err)
+    stopScan()
+  }
+}
+
+async function detectFrame(detector: BarcodeDetectorInstance, video: HTMLVideoElement) {
+  if (detecting || !scanning.value) return
+  detecting = true
+  try {
+    const codes = await detector.detect(video)
+    const raw = codes.find((c) => /^\d{6,14}$/.test(c.rawValue))?.rawValue
+    if (raw) {
+      value.value = raw
+      stopScan()
+      void submit()
+    }
+  } catch {
+    // Transient decode errors are expected between frames — ignore.
+  } finally {
+    detecting = false
+  }
+}
+
+function stopScan() {
+  scanning.value = false
+  detecting = false
+  if (scanTimer !== null) {
+    clearInterval(scanTimer)
+    scanTimer = null
+  }
+  if (stream) {
+    stream.getTracks().forEach((track) => track.stop())
+    stream = null
+  }
+  if (videoRef.value) {
+    videoRef.value.srcObject = null
+  }
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+function errorToMessage(err: unknown): string {
+  const name = typeof err === 'object' && err !== null && 'name' in err ? String(err.name) : ''
+  if (name === 'NotAllowedError' || name === 'SecurityError') {
+    return strings.cameraDenied
+  }
+  if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+    return strings.cameraMissing
+  }
+  return strings.cameraError
+}
+
+async function submit() {
+  const ean = value.value.trim()
+  if (!/^\d{6,14}$/.test(ean)) {
+    error.value = strings.invalid
+    return
+  }
+  error.value = null
+  loading.value = true
+  try {
+    // 1. Shared cache — instant, no external call in the common case.
+    let result = await lookupBarcode(ean)
+    if (!result) {
+      // 2. Cache miss — resolve from the user's own IP, then write back so it
+      //    becomes a permanent free hit for the whole house.
+      result = await resolveExternally(ean)
+      if (result) {
+        try {
+          await saveBarcode(result)
+        } catch {
+          // Write-back is best-effort; a failure just means the next scan
+          // re-resolves. Never block the user on it.
+        }
+      }
+    }
+    emit('resolved', ean, result)
+    emit('update:open', false)
+  } finally {
+    loading.value = false
+  }
+}
+
+const strings = {
+  // TRANSLATORS: Title of the dialog for looking up a product by its barcode.
+  title: t('pantry', 'Look up by barcode'),
+  hint: t('pantry', 'Enter or scan a product barcode (EAN/UPC) to fill in the item details.'),
+  disclaimer: t(
+    'pantry',
+    'Products provided by {linkStart}Open Food Facts{linkEnd}, an external community database that Pantry does not own or control.',
+    {
+      linkStart:
+        '<a href="https://world.openfoodfacts.org" target="_blank" rel="noreferrer noopener">',
+      linkEnd: '</a>',
+    },
+    { escape: false },
+  ),
+  // TRANSLATORS: Label of the text field where the barcode number is typed.
+  eanLabel: t('pantry', 'Barcode'),
+  eanPlaceholder: t('pantry', 'e.g. 4001724819103'),
+  invalid: t('pantry', 'Enter a valid barcode (6 to 14 digits).'),
+  cancel: t('pantry', 'Cancel'),
+  // TRANSLATORS: Verb, button that looks up the entered barcode.
+  lookUp: t('pantry', 'Look up'),
+  looking: t('pantry', 'Looking up …'),
+  // TRANSLATORS: Verb, button that opens the camera to scan a barcode.
+  scan: t('pantry', 'Scan'),
+  // TRANSLATORS: Verb, button that stops the camera barcode scanner.
+  stopScan: t('pantry', 'Stop scanning'),
+  cameraDenied: t(
+    'pantry',
+    'Camera access was denied. Allow it to scan, or enter the barcode manually.',
+  ),
+  cameraMissing: t('pantry', 'No camera was found. Enter the barcode manually.'),
+  cameraError: t('pantry', 'Could not start the camera. Enter the barcode manually.'),
+}
+</script>
+
+<style scoped>
+.pantry-barcode-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px 4px;
+}
+
+.pantry-barcode-form__hint {
+  color: var(--color-text-maxcontrast);
+  font-size: 0.9em;
+}
+
+.pantry-barcode-form__disclaimer {
+  color: var(--color-text-maxcontrast);
+  font-size: 0.8em;
+  font-style: italic;
+}
+
+.pantry-barcode-form__disclaimer :deep(a) {
+  text-decoration: underline;
+}
+
+.pantry-barcode-form__entry {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.pantry-barcode-form__field {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pantry-barcode-form__scan-start {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.pantry-barcode-form__scanner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.pantry-barcode-form__video {
+  width: 100%;
+  max-height: 320px;
+  background: var(--color-background-dark);
+  border-radius: var(--border-radius-large);
+  object-fit: cover;
+}
+
+.pantry-barcode-form__error {
+  color: var(--color-error);
+  font-size: 0.9em;
+}
+</style>

--- a/src/components/BarcodeLookupDialog/index.ts
+++ b/src/components/BarcodeLookupDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BarcodeLookupDialog.vue'

--- a/src/components/ChecklistAddForm/ChecklistAddForm.test.ts
+++ b/src/components/ChecklistAddForm/ChecklistAddForm.test.ts
@@ -6,6 +6,10 @@ import type { ItemInput } from '@/api/lists'
 import type { ChecklistItem } from '@/api/types'
 
 vi.mock('@nextcloud/l10n', () => nextcloudL10nMock)
+vi.mock('@nextcloud/dialogs', () => ({
+  showWarning: vi.fn(),
+  showError: vi.fn(),
+}))
 vi.mock('@icons/Plus.vue', () => createIconMock('PlusIcon'))
 vi.mock('@icons/TagOutline.vue', () => createIconMock('TagOutlineIcon'))
 vi.mock('@icons/ScaleBalance.vue', () => createIconMock('ScaleBalanceIcon'))
@@ -16,6 +20,18 @@ vi.mock('@icons/Repeat.vue', () => createIconMock('RepeatIcon'))
 vi.mock('@icons/Image.vue', () => createIconMock('ImageIcon'))
 vi.mock('@icons/ImagePlus.vue', () => createIconMock('ImagePlusIcon'))
 vi.mock('@icons/Upload.vue', () => createIconMock('UploadIcon'))
+vi.mock('@icons/BarcodeScan.vue', () => createIconMock('BarcodeScanIcon'))
+
+// Stub the barcode dialog so the add-form test doesn't pull in NcDialog (and
+// its CSS asset, which Vitest can't parse).
+vi.mock('@/components/BarcodeLookupDialog', () => ({
+  default: {
+    name: 'BarcodeLookupDialog',
+    template: '<div class="barcode-dialog-stub"></div>',
+    props: ['open'],
+    emits: ['update:open', 'resolved'],
+  },
+}))
 
 vi.mock('@nextcloud/vue/components/NcButton', () => ({
   default: {
@@ -169,6 +185,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,
@@ -216,13 +233,14 @@ describe('ChecklistAddForm', () => {
   it('renders one chip per field section', () => {
     const wrapper = mountForm()
     const chips = wrapper.findAll('.nc-chip')
-    expect(chips).toHaveLength(6)
+    expect(chips).toHaveLength(7)
     expect(chips[0].text()).toContain('Category')
     expect(chips[1].text()).toContain('Stores')
     expect(chips[2].text()).toContain('Quantity')
     expect(chips[3].text()).toContain('Description')
     expect(chips[4].text()).toContain('Item type')
     expect(chips[5].text()).toContain('Image')
+    expect(chips[6].text()).toContain('Barcode')
   })
 
   it('item type chip shows the chosen type text only after explicit selection', async () => {
@@ -270,6 +288,7 @@ describe('ChecklistAddForm', () => {
       rrule: null,
       repeatFromCompletion: false,
       deleteOnDone: false,
+      barcode: null,
     })
     expect(pendingImage).toBeNull()
   })

--- a/src/components/ChecklistAddForm/ChecklistAddForm.vue
+++ b/src/components/ChecklistAddForm/ChecklistAddForm.vue
@@ -80,6 +80,17 @@
         </template>
         {{ chip.text }}
       </PantryChip>
+      <PantryChip
+        v-if="!multiple"
+        :variant="barcode ? 'secondary' : 'tertiary'"
+        class="checklist-add__chip"
+        @click="barcodeDialogOpen = true"
+      >
+        <template #icon>
+          <BarcodeScanIcon :size="14" />
+        </template>
+        {{ barcode ? strings.barcodeAttached : strings.barcode }}
+      </PantryChip>
     </div>
 
     <div v-if="openSection" class="checklist-add__section">
@@ -176,6 +187,8 @@
         />
       </ul>
     </div>
+
+    <BarcodeLookupDialog v-model:open="barcodeDialogOpen" @resolved="onBarcodeResolved" />
   </form>
 </template>
 
@@ -183,6 +196,7 @@
 import { computed, onBeforeUnmount, ref, watch, type Component } from 'vue'
 import { extract, token_set_ratio } from 'fuzzball'
 import { t, n } from '@nextcloud/l10n'
+import { showWarning } from '@nextcloud/dialogs'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
@@ -198,6 +212,7 @@ import RepeatIcon from '@icons/Repeat.vue'
 import ImageIcon from '@icons/Image.vue'
 import ImagePlusIcon from '@icons/ImagePlus.vue'
 import UploadIcon from '@icons/Upload.vue'
+import BarcodeScanIcon from '@icons/BarcodeScan.vue'
 import { AutoResizeTextarea } from '@/components/AutoResizeTextarea'
 import { RecurrenceForm } from '@/components/RecurrenceEditor'
 import CategoryChipList from '@/components/CategoryChipList'
@@ -205,7 +220,9 @@ import StoreChipList from '@/components/StoreChipList'
 import ItemTypeSelector from '@/components/ItemTypeSelector'
 import QuantityInput from '@/components/QuantityInput'
 import PantryChip from '@/components/PantryChip'
+import BarcodeLookupDialog from '@/components/BarcodeLookupDialog'
 import { ChecklistItemRow } from '@/components/ChecklistItemRow'
+import { type BarcodeResult } from '@/api/barcode'
 import { useCategories } from '@/composables/useCategories'
 import { useStores } from '@/composables/useStores'
 import { categoryIconComponent } from '@/components/CategoryPicker/categoryIcons'
@@ -261,6 +278,8 @@ const rrule = ref<string | null>(null)
 const repeatFromCompletion = ref(false)
 const deleteOnDone = ref(props.deleteOnDoneDefault)
 const openSection = ref<SectionKey | null>(null)
+const barcode = ref<string | null>(null)
+const barcodeDialogOpen = ref(false)
 
 interface ListOption {
   value: number
@@ -401,6 +420,65 @@ function clearPendingImage() {
 }
 
 onBeforeUnmount(revokeObjectUrl)
+
+// ----- Barcode -----
+//
+// A resolved barcode prefills the draft: name, a best-match category, and the
+// product image. On an unknown barcode we still stamp the code as the name so
+// the user can rename it — the raw EAN is never lost.
+
+function onBarcodeResolved(ean: string, result: BarcodeResult | null) {
+  if (!result) {
+    // Unknown barcode: leave the form untouched (cleared or with whatever the
+    // user had already typed) and just let them know.
+    showWarning(t('pantry', 'No product found for barcode {ean}.', { ean }))
+    return
+  }
+  barcode.value = ean
+  name.value = result.name
+  const matched = matchCategory(result.category)
+  if (matched && categoryId.value == null) {
+    categoryId.value = matched.id
+  }
+  if (result.imageUrl && !multiple.value) {
+    void prefillImageFromUrl(result.imageUrl)
+  }
+}
+
+/**
+ * Fuzzy-match a provider category hint (e.g. "Beverages") against the house's
+ * own categories, reusing the fuzzball scorer used for reuse suggestions.
+ */
+function matchCategory(hint: string | null): Category | null {
+  if (!hint || categories.value.length === 0) return null
+  const results = extract(hint, categories.value, {
+    processor: (c: Category) => c.name,
+    scorer: token_set_ratio,
+    limit: 1,
+    cutoff: 65,
+  })
+  return results.length > 0 ? (results[0]![0] as Category) : null
+}
+
+/**
+ * Download the product image from its URL and stage it as the pending item
+ * image. Best-effort: a CORS failure or non-image response is silently ignored.
+ */
+async function prefillImageFromUrl(url: string) {
+  try {
+    const resp = await fetch(url)
+    if (!resp.ok) return
+    const blob = await resp.blob()
+    if (!blob.type.startsWith('image/')) return
+    const ext = blob.type.split('/')[1] || 'jpg'
+    const file = new File([blob], `barcode-product.${ext}`, { type: blob.type })
+    revokeObjectUrl()
+    pendingImage.value = file
+    pendingImageObjectUrl.value = URL.createObjectURL(file)
+  } catch {
+    // Ignore — image prefill is a bonus, never a blocker.
+  }
+}
 
 // ----- Chips -----
 
@@ -587,6 +665,9 @@ function submitAdd() {
         rrule: once ? null : rrule.value,
         repeatFromCompletion: once ? false : repeatFromCompletion.value,
         deleteOnDone: once,
+        // A barcode identifies a single product, so only the first line of a
+        // bulk add carries it.
+        barcode: index === 0 ? barcode.value : null,
       },
       index === 0 ? pendingImage.value : null,
       targetListId.value,
@@ -600,6 +681,7 @@ function submitAdd() {
   storeIds.value = []
   rrule.value = null
   repeatFromCompletion.value = false
+  barcode.value = null
   // Keep the user's last-chosen list default.
   deleteOnDone.value = props.deleteOnDoneDefault
   userPickedType.value = false
@@ -635,6 +717,10 @@ const strings = {
   replaceImage: t('pantry', 'Replace image'),
   removeImage: t('pantry', 'Remove image'),
   imageAlt: t('pantry', 'Selected image'),
+  // TRANSLATORS: Noun, chip button that opens the barcode lookup dialog to fill in the item from a product barcode.
+  barcode: t('pantry', 'Barcode'),
+  // TRANSLATORS: State of the barcode chip once a barcode has been attached to the item being added.
+  barcodeAttached: t('pantry', 'Barcode attached'),
   // TRANSLATORS: Header above the list of existing items that match what the user is typing, offered so they can reuse one instead of adding a duplicate.
   suggestionsHeader: t('pantry', 'Already on this list'),
 }

--- a/src/components/ChecklistFilter/ChecklistFilter.test.ts
+++ b/src/components/ChecklistFilter/ChecklistFilter.test.ts
@@ -85,6 +85,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/ChecklistImagePreview/ChecklistImagePreview.test.ts
+++ b/src/components/ChecklistImagePreview/ChecklistImagePreview.test.ts
@@ -39,6 +39,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: 77,
     imageUploadedBy: 'admin',
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/ChecklistItemEditDialog/ChecklistItemEditDialog.test.ts
+++ b/src/components/ChecklistItemEditDialog/ChecklistItemEditDialog.test.ts
@@ -112,6 +112,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/ChecklistItemRow/ChecklistItemRow.test.ts
+++ b/src/components/ChecklistItemRow/ChecklistItemRow.test.ts
@@ -123,6 +123,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/ChecklistItemViewDialog/ChecklistItemViewDialog.test.ts
+++ b/src/components/ChecklistItemViewDialog/ChecklistItemViewDialog.test.ts
@@ -70,6 +70,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/MarkdownExportDialog/MarkdownExportDialog.test.ts
+++ b/src/components/MarkdownExportDialog/MarkdownExportDialog.test.ts
@@ -60,6 +60,7 @@ function item(partial: Partial<ChecklistItem>): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/composables/useChecklist.test.ts
+++ b/src/composables/useChecklist.test.ts
@@ -68,6 +68,7 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/utils/markdownList.test.ts
+++ b/src/utils/markdownList.test.ts
@@ -25,6 +25,7 @@ function item(partial: Partial<ChecklistItem>): ChecklistItem {
     imageFileId: null,
     imageUploadedBy: null,
     addedBy: null,
+    barcode: null,
     sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,3 +5,9 @@ declare module '@icons/*.vue' {
   const component: DefineComponent<object, object, unknown>
   export default component
 }
+
+// Local zxing barcode-reader wasm URL, emitted by the zxingWasmAsset() Vite plugin.
+declare module 'virtual:zxing-reader-wasm-url' {
+  const url: string
+  export default url
+}

--- a/tests/unit/Controller/BarcodeControllerTest.php
+++ b/tests/unit/Controller/BarcodeControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Tests\Unit\Controller;
+
+use OCA\Pantry\Controller\BarcodeController;
+use OCA\Pantry\Db\BarcodeCache;
+use OCA\Pantry\Service\BarcodeService;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class BarcodeControllerTest extends TestCase {
+	/** @var BarcodeService&MockObject */
+	private BarcodeService $barcodes;
+	private BarcodeController $controller;
+
+	protected function setUp(): void {
+		$this->barcodes = $this->createMock(BarcodeService::class);
+		$this->controller = new BarcodeController(
+			'pantry',
+			$this->createMock(IRequest::class),
+			$this->barcodes,
+		);
+	}
+
+	private function makeCache(): BarcodeCache {
+		$c = new BarcodeCache();
+		$c->setEan('4001724819103');
+		$c->setName('Cola Zero');
+		$c->setBrand('Acme');
+		$c->setCategory('Beverages');
+		$c->setImageUrl('https://images/x.jpg');
+		$c->setProvider('openfoodfacts');
+		return $c;
+	}
+
+	public function testShowReturnsCachedBarcode(): void {
+		$this->barcodes->method('getFromCache')->with('4001724819103')->willReturn($this->makeCache());
+
+		$response = $this->controller->show('4001724819103');
+
+		$this->assertSame([
+			'ean' => '4001724819103',
+			'name' => 'Cola Zero',
+			'brand' => 'Acme',
+			'category' => 'Beverages',
+			'imageUrl' => 'https://images/x.jpg',
+			'provider' => 'openfoodfacts',
+		], $response->getData());
+	}
+
+	public function testShowThrowsNotFoundOnMiss(): void {
+		$this->barcodes->method('getFromCache')->willReturn(null);
+		$this->expectException(OCSNotFoundException::class);
+		$this->controller->show('0000000000000');
+	}
+
+	public function testStoreDelegatesToService(): void {
+		$this->barcodes->expects($this->once())
+			->method('saveResult')
+			->with($this->callback(fn (array $d) => $d['ean'] === '4001724819103' && $d['name'] === 'Cola Zero'))
+			->willReturn($this->makeCache());
+
+		$response = $this->controller->store('4001724819103', 'Cola Zero', 'Acme', 'Beverages', 'https://images/x.jpg', 'openfoodfacts');
+		$this->assertSame('Cola Zero', $response->getData()['name']);
+	}
+}

--- a/tests/unit/Service/Barcode/OpenFoodFactsProviderTest.php
+++ b/tests/unit/Service/Barcode/OpenFoodFactsProviderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Tests\Unit\Service\Barcode;
+
+use OCA\Pantry\Service\Barcode\OpenFoodFactsProvider;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OpenFoodFactsProviderTest extends TestCase {
+	/** @var IClientService&MockObject */
+	private IClientService $clientService;
+	/** @var IClient&MockObject */
+	private IClient $client;
+	/** @var LoggerInterface&MockObject */
+	private LoggerInterface $logger;
+	private OpenFoodFactsProvider $provider;
+
+	protected function setUp(): void {
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->client = $this->createMock(IClient::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->clientService->method('newClient')->willReturn($this->client);
+		$this->provider = new OpenFoodFactsProvider($this->clientService, $this->logger);
+	}
+
+	private function respondWith(string $body): void {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getBody')->willReturn($body);
+		$this->client->method('get')->willReturn($response);
+	}
+
+	public function testLookupMapsProductFields(): void {
+		$this->client->expects($this->once())
+			->method('get')
+			->with(
+				$this->stringContains('/api/v2/product/4001724819103.json'),
+				$this->callback(fn (array $opts) => isset($opts['headers']['User-Agent'])),
+			)
+			->willReturn($this->makeResponse(json_encode([
+				'status' => 1,
+				'product' => [
+					'product_name' => 'Cola Zero',
+					'brands' => 'Acme, SubBrand',
+					'categories' => 'Beverages, Sodas',
+					'image_url' => 'https://images/x.jpg',
+				],
+			])));
+
+		$result = $this->provider->lookup('4001724819103');
+
+		$this->assertNotNull($result);
+		$this->assertSame('4001724819103', $result->ean);
+		$this->assertSame('Cola Zero', $result->name);
+		$this->assertSame('Acme', $result->brand);
+		$this->assertSame('Beverages', $result->category);
+		$this->assertSame('https://images/x.jpg', $result->imageUrl);
+		$this->assertSame(OpenFoodFactsProvider::ID, $result->provider);
+	}
+
+	public function testLookupReturnsNullWhenNotFound(): void {
+		$this->respondWith(json_encode(['status' => 0, 'status_verbose' => 'product not found']));
+		$this->assertNull($this->provider->lookup('0000000000000'));
+	}
+
+	public function testLookupReturnsNullWhenNoName(): void {
+		$this->respondWith(json_encode(['status' => 1, 'product' => ['brands' => 'Acme']]));
+		$this->assertNull($this->provider->lookup('4001724819103'));
+	}
+
+	public function testLookupReturnsNullOnHttpError(): void {
+		$this->client->method('get')->willThrowException(new \RuntimeException('boom'));
+		$this->assertNull($this->provider->lookup('4001724819103'));
+	}
+
+	public function testLookupFallsBackToGenericName(): void {
+		$this->respondWith(json_encode([
+			'status' => 1,
+			'product' => ['generic_name' => 'Sparkling water'],
+		]));
+		$result = $this->provider->lookup('4001724819103');
+		$this->assertNotNull($result);
+		$this->assertSame('Sparkling water', $result->name);
+	}
+
+	private function makeResponse(string $body): IResponse {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getBody')->willReturn($body);
+		return $response;
+	}
+}

--- a/tests/unit/Service/BarcodeServiceTest.php
+++ b/tests/unit/Service/BarcodeServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Tests\Unit\Service;
+
+use OCA\Pantry\Db\BarcodeCache;
+use OCA\Pantry\Db\BarcodeCacheMapper;
+use OCA\Pantry\Service\Barcode\BarcodeResult;
+use OCA\Pantry\Service\Barcode\OpenFoodFactsProvider;
+use OCA\Pantry\Service\BarcodeService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class BarcodeServiceTest extends TestCase {
+	/** @var BarcodeCacheMapper&MockObject */
+	private BarcodeCacheMapper $mapper;
+	/** @var IAppConfig&MockObject */
+	private IAppConfig $appConfig;
+	/** @var OpenFoodFactsProvider&MockObject */
+	private OpenFoodFactsProvider $provider;
+	private BarcodeService $svc;
+
+	protected function setUp(): void {
+		$this->mapper = $this->createMock(BarcodeCacheMapper::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->provider = $this->createMock(OpenFoodFactsProvider::class);
+		$this->provider->method('getId')->willReturn(OpenFoodFactsProvider::ID);
+		$this->svc = new BarcodeService($this->mapper, $this->appConfig, $this->provider);
+	}
+
+	public function testGetFromCacheDelegatesToMapper(): void {
+		$entity = new BarcodeCache();
+		$this->mapper->expects($this->once())
+			->method('findByEan')
+			->with('4001724819103')
+			->willReturn($entity);
+
+		$this->assertSame($entity, $this->svc->getFromCache('4001724819103'));
+	}
+
+	public function testGetFromCacheRejectsNonNumericEan(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->svc->getFromCache('not-a-barcode');
+	}
+
+	public function testSaveResultInsertsWhenNew(): void {
+		$this->mapper->method('findByEan')->willReturn(null);
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(fn (BarcodeCache $c) => $c);
+		$this->mapper->expects($this->never())->method('update');
+
+		$saved = $this->svc->saveResult([
+			'ean' => '4001724819103',
+			'name' => 'Cola',
+			'brand' => 'Acme',
+			'category' => 'Beverages',
+			'imageUrl' => 'https://img/x.jpg',
+			'provider' => 'openfoodfacts',
+		]);
+
+		$this->assertSame('4001724819103', $saved->getEan());
+		$this->assertSame('Cola', $saved->getName());
+		$this->assertSame('Beverages', $saved->getCategory());
+		$this->assertGreaterThan(0, $saved->getResolvedAt());
+	}
+
+	public function testSaveResultUpdatesWhenExisting(): void {
+		$existing = new BarcodeCache();
+		$existing->setEan('4001724819103');
+		$this->mapper->method('findByEan')->willReturn($existing);
+		$this->mapper->expects($this->once())
+			->method('update')
+			->willReturnCallback(fn (BarcodeCache $c) => $c);
+		$this->mapper->expects($this->never())->method('insert');
+
+		$saved = $this->svc->saveResult(['ean' => '4001724819103', 'name' => 'Cola']);
+		$this->assertSame('Cola', $saved->getName());
+	}
+
+	public function testSaveResultRejectsEmptyName(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->svc->saveResult(['ean' => '4001724819103', 'name' => '   ']);
+	}
+
+	public function testSaveResultDefaultsProviderToClient(): void {
+		$this->mapper->method('findByEan')->willReturn(null);
+		$this->mapper->method('insert')->willReturnCallback(fn (BarcodeCache $c) => $c);
+
+		$saved = $this->svc->saveResult(['ean' => '12345678', 'name' => 'Thing']);
+		$this->assertSame('client', $saved->getProvider());
+	}
+
+	public function testResolveViaProviderUsesConfiguredProvider(): void {
+		$this->appConfig->method('getValueString')->willReturn(OpenFoodFactsProvider::ID);
+		$result = new BarcodeResult('12345678', 'Thing', null, null, null, OpenFoodFactsProvider::ID);
+		$this->provider->expects($this->once())
+			->method('lookup')
+			->with('12345678')
+			->willReturn($result);
+
+		$this->assertSame($result, $this->svc->resolveViaProvider('12345678'));
+	}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,37 @@
 import { createAppConfig } from '@nextcloud/vite-config'
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'path'
 import { visualizer } from 'rollup-plugin-visualizer'
 import checker from 'vite-plugin-checker'
+
+const require = createRequire(import.meta.url)
+
+// Emit the zxing barcode-reader wasm as a local app asset and expose its
+// hashed URL via a virtual module. This lets the scanner ponyfill (used on
+// browsers without a native BarcodeDetector) load the wasm from the app origin
+// instead of the package's default jsDelivr CDN, which Nextcloud's CSP blocks.
+function zxingWasmAsset() {
+  const virtualId = 'virtual:zxing-reader-wasm-url'
+  const resolvedId = '\0' + virtualId
+  return {
+    name: 'pantry-zxing-wasm-asset',
+    resolveId(id: string) {
+      if (id === virtualId) return resolvedId
+    },
+    load(this: { emitFile: (f: object) => string }, id: string) {
+      if (id === resolvedId) {
+        const wasmPath = require.resolve('zxing-wasm/reader/zxing_reader.wasm')
+        const ref = this.emitFile({
+          type: 'asset',
+          name: 'zxing_reader.wasm',
+          source: readFileSync(wasmPath),
+        })
+        return `export default import.meta.ROLLUP_FILE_URL_${ref}`
+      }
+    },
+  }
+}
 
 const manualChunksList = [
   'emoji-mart-vue-fast',
@@ -47,6 +76,7 @@ export default createAppConfig(
         },
       },
       plugins: [
+        zxingWasmAsset(),
         {
           name: 'clean-dist-js',
           generateBundle() {


### PR DESCRIPTION
## Summary

Adds EAN/UPC barcode lookup: **scan with the camera or type** a product barcode to look up its details and prepopulate a checklist item. A shared server-side cache turns repeat scans into free instant hits; genuinely-new barcodes are resolved once by the client (from its own IP) and written back so they're free for the whole house forever.

Scope: the shared backend foundation + the full web UI (manual entry **and** camera scanning). The Flutter companion app consumes the same endpoints for its own native scanner.

## Backend

- **Migration `Version18`** — global `pantry_barcode_cache` table (`ean` unique, name, brand, category, image_url, provider, raw, resolved_at) + a nullable `barcode` column on `pantry_list_items`.
- **Db** — `BarcodeCache` entity + `BarcodeCacheMapper` (`findByEan`); `barcode` added to `ChecklistItem`.
- **Provider abstraction** (`lib/Service/Barcode/`) — `BarcodeLookupProvider` interface + `BarcodeResult` DTO, shipping `OpenFoodFactsProvider` (the app's first outbound HTTP via `IClientService`). Provider selected by the `barcode_provider` app-config value.
- **`BarcodeService`** — cache-get / write-back upsert / provider-resolve, with EAN validation.
- **`BarcodeController`** — `GET /api/barcode/{ean}` (cache hit or 404) and `POST /api/barcode` (client write-back), auth-only. `barcode` threaded through item create/update. `PantryBarcode` type + regenerated `openapi.json`.

## Web

- `barcode` on `ChecklistItem`/`ItemInput`; new `src/api/barcode.ts` (cache lookup, write-back, and external Open Food Facts resolution via native `fetch` — never the Nextcloud axios instance, so no CSRF token leaks cross-origin).
- New `BarcodeLookupDialog` + a barcode chip in the add form, with both **manual entry** and a **camera Scan** mode. On resolve it prefills **name**, does a fuzzball **best-match category** against the house's categories, and **fetches + stages the product image**, all reusing the existing add → image-upload path. Unknown barcodes fall back to stamping the raw EAN as the name.
- **Camera scanning** uses the browser's native `BarcodeDetector` where available (Chrome/Edge/Android — no wasm). For Firefox/Safari it falls back to the zxing wasm ponyfill, served as a **local app asset** (via a Vite plugin) instead of the package's default CDN, with the app's CSP relaxed via `allowEvalWasm()` so it can execute. The Scan button only appears in a secure context (HTTPS / localhost), which is where `getUserMedia` is available.

## Deferred (not in this PR)

- Server-side proxy + throttled ≤10/min queue (only needed for a rate-limited/CORS-blocked provider; moot with Open Food Facts' open CORS).

## Testing

- Backend: 255 PHPUnit tests pass; migration applies; `db:add-missing-*` confirm schema matches; endpoint round-trip verified (404 → POST → 200 hit); item-with-barcode create persists and round-trips.
- Frontend: typecheck clean, 467 tests pass, eslint clean (added `barcode.test.ts`). Production build verified — wasm emitted as a local hashed asset (`import.meta.url`-relative, no CDN), and the page CSP header carries `wasm-unsafe-eval`.
- Confirmed the real Open Food Facts response shape matches the field mapping.

## Screenshot

<img width="605" height="195" alt="image" src="https://github.com/user-attachments/assets/ce1c6a2f-81a7-40d5-891a-70403583e925" />

## Misc

Closes #147
