### PR TITLE
feat(stores): sort and group checklist by store with manual reorder

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -55,6 +55,7 @@ class Capabilities implements IPublicCapability {
 					'categories',
 					'category-sort',
 					'stores',
+					'store-sort',
 					'barcode',
 					'item-price',
 					'shopping',

--- a/lib/Controller/PrefsController.php
+++ b/lib/Controller/PrefsController.php
@@ -131,6 +131,7 @@ final class PrefsController extends OCSController {
 	 * @param string|null $checklistItemSort Checklist item sort mode.
 	 * @param string|null $checklistSort Checklist (list) sort mode (name_asc, name_desc, custom).
 	 * @param string|null $categorySort Category sort mode (name_asc, name_desc, custom).
+	 * @param string|null $storeSort Store sort mode (name_asc, name_desc, custom).
 	 * @param bool|null $showAddedBy Show the avatar of the user that added each checklist item.
 	 * @param string|null $lastCurrency Last-used currency code (ISO 4217) for item prices in this house.
 	 * @param bool|null $notifyPhoto Photo upload notifications.
@@ -155,6 +156,7 @@ final class PrefsController extends OCSController {
 		?string $checklistItemSort = null,
 		?string $checklistSort = null,
 		?string $categorySort = null,
+		?string $storeSort = null,
 		?bool $showAddedBy = null,
 		?string $lastCurrency = null,
 		?bool $notifyPhoto = null,
@@ -164,7 +166,7 @@ final class PrefsController extends OCSController {
 		?bool $notifyItemRecur = null,
 		?bool $notifyItemDone = null,
 	): DataResponse {
-		return $this->runAction(function () use ($houseId, $imageFolder, $photoSort, $photoFoldersFirst, $noteSort, $checklistItemSort, $checklistSort, $categorySort, $showAddedBy, $lastCurrency, $notifyPhoto, $notifyNoteCreate, $notifyNoteEdit, $notifyItemAdd, $notifyItemRecur, $notifyItemDone): DataResponse {
+		return $this->runAction(function () use ($houseId, $imageFolder, $photoSort, $photoFoldersFirst, $noteSort, $checklistItemSort, $checklistSort, $categorySort, $storeSort, $showAddedBy, $lastCurrency, $notifyPhoto, $notifyNoteCreate, $notifyNoteEdit, $notifyItemAdd, $notifyItemRecur, $notifyItemDone): DataResponse {
 			$uid = $this->requireUid();
 			$this->auth->requireMember($houseId, $uid);
 			$patch = array_filter([
@@ -175,6 +177,7 @@ final class PrefsController extends OCSController {
 				'checklistItemSort' => $checklistItemSort,
 				'checklistSort' => $checklistSort,
 				'categorySort' => $categorySort,
+				'storeSort' => $storeSort,
 				'showAddedBy' => $showAddedBy,
 				'lastCurrency' => $lastCurrency,
 				'notifyPhoto' => $notifyPhoto,

--- a/lib/Controller/StoreController.php
+++ b/lib/Controller/StoreController.php
@@ -11,6 +11,7 @@ use OCA\Pantry\Exception\ForbiddenException;
 use OCA\Pantry\Permission\Permission;
 use OCA\Pantry\ResponseDefinitions;
 use OCA\Pantry\Service\HouseAuthService;
+use OCA\Pantry\Service\PrefsService;
 use OCA\Pantry\Service\StoreService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -32,6 +33,7 @@ final class StoreController extends OCSController {
 		IRequest $request,
 		private StoreService $stores,
 		private HouseAuthService $auth,
+		private PrefsService $prefs,
 		private IUserSession $userSession,
 	) {
 		parent::__construct($appName, $request);
@@ -55,7 +57,8 @@ final class StoreController extends OCSController {
 		return $this->runAction(function () use ($houseId, $limit, $offset): DataResponse {
 			$uid = $this->requireUid();
 			$this->auth->requireMember($houseId, $uid);
-			$all = $this->stores->listForHouse($houseId);
+			$sortBy = $this->prefs->getStoreSort($uid, $houseId);
+			$all = $this->stores->listForHouse($houseId, $sortBy);
 			$sliced = array_slice($all, max(0, $offset), max(0, $limit));
 			return new DataResponse(array_map(fn ($s) => $s->jsonSerialize(), $sliced));
 		});
@@ -116,6 +119,7 @@ final class StoreController extends OCSController {
 	 * @param string|null $contact Phone, social or other contact details. Empty string clears it.
 	 * @param string|null $responsible Person responsible for the store. Empty string clears it.
 	 * @param string|null $notes Free-form notes. Empty string clears it.
+	 * @param int|null $sortOrder New sort order.
 	 *
 	 * @return DataResponse<Http::STATUS_OK, PantryStore, array{}>
 	 *
@@ -136,8 +140,9 @@ final class StoreController extends OCSController {
 		?string $contact = null,
 		?string $responsible = null,
 		?string $notes = null,
+		?int $sortOrder = null,
 	): DataResponse {
-		return $this->runAction(function () use ($houseId, $storeId, $name, $icon, $color, $brand, $location, $openingHours, $contact, $responsible, $notes): DataResponse {
+		return $this->runAction(function () use ($houseId, $storeId, $name, $icon, $color, $brand, $location, $openingHours, $contact, $responsible, $notes, $sortOrder): DataResponse {
 			$this->auth->requireMember($houseId, $this->requireUid());
 			$this->stores->assertInHouse($storeId, $houseId);
 			$patch = [];
@@ -149,6 +154,9 @@ final class StoreController extends OCSController {
 			}
 			if ($color !== null) {
 				$patch['color'] = $color;
+			}
+			if ($sortOrder !== null) {
+				$patch['sortOrder'] = $sortOrder;
 			}
 			$patch += $this->collectInfo($brand, $location, $openingHours, $contact, $responsible, $notes);
 			$updated = $this->stores->update($storeId, $patch);
@@ -192,6 +200,27 @@ final class StoreController extends OCSController {
 			$info['notes'] = $notes;
 		}
 		return $info;
+	}
+
+	/**
+	 * Batch reorder stores
+	 *
+	 * @param int $houseId House id.
+	 * @param list<array{id: int, sortOrder: int}> $items Reorder entries.
+	 *
+	 * @return DataResponse<Http::STATUS_OK, PantrySuccess, array{}>
+	 *
+	 * 200: Stores reordered
+	 */
+	#[ApiRoute(verb: 'POST', url: '/api/houses/{houseId}/stores/reorder')]
+	#[NoAdminRequired]
+	#[Permission(['canEditLists'])]
+	public function reorder(int $houseId, array $items = []): DataResponse {
+		return $this->runAction(function () use ($houseId, $items): DataResponse {
+			$this->auth->requireMember($houseId, $this->requireUid());
+			$this->stores->reorder($houseId, $items);
+			return new DataResponse(['success' => true]);
+		});
 	}
 
 	/**

--- a/lib/Db/Store.php
+++ b/lib/Db/Store.php
@@ -30,6 +30,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setResponsible(?string $responsible)
  * @method string|null getNotes()
  * @method void setNotes(?string $notes)
+ * @method int getSortOrder()
+ * @method void setSortOrder(int $sortOrder)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  * @method int getUpdatedAt()
@@ -46,11 +48,13 @@ class Store extends Entity implements \JsonSerializable {
 	protected ?string $contact = null;
 	protected ?string $responsible = null;
 	protected ?string $notes = null;
+	protected int $sortOrder = 0;
 	protected int $createdAt = 0;
 	protected int $updatedAt = 0;
 
 	public function __construct() {
 		$this->addType('houseId', 'integer');
+		$this->addType('sortOrder', 'integer');
 		$this->addType('createdAt', 'integer');
 		$this->addType('updatedAt', 'integer');
 	}
@@ -70,6 +74,7 @@ class Store extends Entity implements \JsonSerializable {
 			'contact' => $this->contact,
 			'responsible' => $this->responsible,
 			'notes' => $this->notes,
+			'sortOrder' => $this->sortOrder,
 			'createdAt' => $this->createdAt,
 			'updatedAt' => $this->updatedAt,
 		];

--- a/lib/Db/StoreMapper.php
+++ b/lib/Db/StoreMapper.php
@@ -22,15 +22,45 @@ class StoreMapper extends QBMapper {
 	}
 
 	/**
+	 * @param string $sortBy One of: name_asc, name_desc, custom.
+	 *
 	 * @return Store[]
 	 */
-	public function findByHouse(int $houseId): array {
+	public function findByHouse(int $houseId, string $sortBy = 'name_asc'): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('house_id', $qb->createNamedParameter($houseId, IQueryBuilder::PARAM_INT)))
-			->orderBy('name', 'ASC');
+			->where($qb->expr()->eq('house_id', $qb->createNamedParameter($houseId, IQueryBuilder::PARAM_INT)));
+
+		switch ($sortBy) {
+			case 'name_desc':
+				$qb->orderBy('name', 'DESC');
+				break;
+			case 'custom':
+				$qb->orderBy('sort_order', 'ASC')
+					->addOrderBy('name', 'ASC');
+				break;
+			default: // name_asc
+				$qb->orderBy('name', 'ASC');
+				break;
+		}
 		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Highest sort_order currently used in a house, or -1 when the house has no
+	 * stores yet — so a caller can assign `max + 1` to append a new store at the
+	 * end of the custom order.
+	 */
+	public function findMaxSortOrder(int $houseId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->max('sort_order'))
+			->from($this->getTableName())
+			->where($qb->expr()->eq('house_id', $qb->createNamedParameter($houseId, IQueryBuilder::PARAM_INT)));
+		$result = $qb->executeQuery();
+		$max = $result->fetchOne();
+		$result->closeCursor();
+		return $max === null || $max === false ? -1 : (int)$max;
 	}
 
 	/**

--- a/lib/Migration/Version22Date20260806000000.php
+++ b/lib/Migration/Version22Date20260806000000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: Chen Asraf <contact@casraf.dev>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Pantry\Migration;
+
+use Closure;
+use OCA\Pantry\AppInfo\Application;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add a custom sort order to stores, so they can be manually reordered and used
+ * to group checklist items the same way categories are.
+ */
+class Version22Date20260806000000 extends SimpleMigrationStep {
+	/**
+	 * @param Closure():ISchemaWrapper $schemaClosure
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$storesTable = Application::tableName('stores');
+		if (!$schema->hasTable($storesTable)) {
+			return null;
+		}
+		$table = $schema->getTable($storesTable);
+
+		if (!$table->hasColumn('sort_order')) {
+			$table->addColumn('sort_order', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -141,6 +141,7 @@ namespace OCA\Pantry;
  *     contact: string|null,
  *     responsible: string|null,
  *     notes: string|null,
+ *     sortOrder: int,
  *     createdAt: int,
  *     updatedAt: int,
  * }
@@ -262,6 +263,7 @@ namespace OCA\Pantry;
  *     checklistItemSort: string,
  *     checklistSort: string,
  *     categorySort: string,
+ *     storeSort: string,
  *     showAddedBy: bool,
  *     lastCurrency: string,
  *     notifyPhoto: bool,

--- a/lib/Service/PrefsService.php
+++ b/lib/Service/PrefsService.php
@@ -204,7 +204,7 @@ class PrefsService {
 	}
 
 	public function setChecklistItemSort(string $uid, int $houseId, string $sort): string {
-		$allowed = ['custom', 'newest', 'oldest', 'name_asc', 'name_desc', 'category'];
+		$allowed = ['custom', 'newest', 'oldest', 'name_asc', 'name_desc', 'category', 'store'];
 		if (!in_array($sort, $allowed, true)) {
 			$sort = 'custom';
 		}
@@ -231,6 +231,28 @@ class PrefsService {
 			$sort = 'name_asc';
 		}
 		$this->config->setUserValue($uid, Application::APP_ID, self::KEY_CATEGORY_SORT . '_' . $houseId, $sort);
+		return $sort;
+	}
+
+	// ----- Store sort preferences -----
+
+	private const KEY_STORE_SORT = 'store_sort';
+	public const STORE_SORT_OPTIONS = ['name_asc', 'name_desc', 'custom'];
+
+	public function getStoreSort(string $uid, int $houseId): string {
+		return $this->config->getUserValue(
+			$uid,
+			Application::APP_ID,
+			self::KEY_STORE_SORT . '_' . $houseId,
+			'name_asc',
+		);
+	}
+
+	public function setStoreSort(string $uid, int $houseId, string $sort): string {
+		if (!in_array($sort, self::STORE_SORT_OPTIONS, true)) {
+			$sort = 'name_asc';
+		}
+		$this->config->setUserValue($uid, Application::APP_ID, self::KEY_STORE_SORT . '_' . $houseId, $sort);
 		return $sort;
 	}
 
@@ -354,6 +376,7 @@ class PrefsService {
 			'checklistItemSort' => $this->getChecklistItemSort($uid, $houseId),
 			'checklistSort' => $this->getChecklistSort($uid, $houseId),
 			'categorySort' => $this->getCategorySort($uid, $houseId),
+			'storeSort' => $this->getStoreSort($uid, $houseId),
 			'showAddedBy' => $this->getShowAddedBy($uid, $houseId),
 			'lastCurrency' => $this->getLastCurrency($uid, $houseId),
 			...$this->getNotificationPrefs($uid, $houseId),
@@ -384,6 +407,9 @@ class PrefsService {
 		}
 		if (array_key_exists('categorySort', $patch) && is_string($patch['categorySort'])) {
 			$this->setCategorySort($uid, $houseId, $patch['categorySort']);
+		}
+		if (array_key_exists('storeSort', $patch) && is_string($patch['storeSort'])) {
+			$this->setStoreSort($uid, $houseId, $patch['storeSort']);
 		}
 		if (array_key_exists('showAddedBy', $patch) && is_bool($patch['showAddedBy'])) {
 			$this->setShowAddedBy($uid, $houseId, $patch['showAddedBy']);

--- a/lib/Service/StoreService.php
+++ b/lib/Service/StoreService.php
@@ -23,8 +23,34 @@ class StoreService {
 	/**
 	 * @return Store[]
 	 */
-	public function listForHouse(int $houseId): array {
-		return $this->mapper->findByHouse($houseId);
+	public function listForHouse(int $houseId, string $sortBy = 'name_asc'): array {
+		return $this->mapper->findByHouse($houseId, $sortBy);
+	}
+
+	/**
+	 * Batch reorder stores in a house.
+	 *
+	 * @param list<array{id: int, sortOrder: int}> $items
+	 */
+	public function reorder(int $houseId, array $items): void {
+		foreach ($items as $entry) {
+			$id = (int)($entry['id'] ?? 0);
+			$sortOrder = (int)($entry['sortOrder'] ?? 0);
+			if ($id <= 0) {
+				continue;
+			}
+			try {
+				$store = $this->mapper->findById($id);
+			} catch (DoesNotExistException) {
+				continue;
+			}
+			if ($store->getHouseId() !== $houseId) {
+				continue;
+			}
+			$store->setSortOrder($sortOrder);
+			$store->setUpdatedAt(time());
+			$this->mapper->update($store);
+		}
 	}
 
 	public function get(int $storeId): Store {
@@ -58,6 +84,9 @@ class StoreService {
 		$store->setIcon($icon);
 		$store->setColor($color);
 		$this->applyInfoFields($store, $info);
+		// Append at the end of the custom order so a custom-sorted list keeps a
+		// stable order instead of tying every new store at 0 (see category #113).
+		$store->setSortOrder($this->mapper->findMaxSortOrder($houseId) + 1);
 		$store->setCreatedAt($now);
 		$store->setUpdatedAt($now);
 		/** @var Store $saved */
@@ -85,6 +114,9 @@ class StoreService {
 		}
 		if (isset($patch['color'])) {
 			$store->setColor($this->normalizeColor((string)$patch['color']));
+		}
+		if (isset($patch['sortOrder'])) {
+			$store->setSortOrder((int)$patch['sortOrder']);
 		}
 		$this->applyInfoFields($store, $patch);
 		$store->setUpdatedAt(time());

--- a/openapi.json
+++ b/openapi.json
@@ -330,6 +330,7 @@
                     "checklistItemSort",
                     "checklistSort",
                     "categorySort",
+                    "storeSort",
                     "showAddedBy",
                     "lastCurrency",
                     "notifyPhoto",
@@ -359,6 +360,9 @@
                         "type": "string"
                     },
                     "categorySort": {
+                        "type": "string"
+                    },
+                    "storeSort": {
                         "type": "string"
                     },
                     "showAddedBy": {
@@ -1407,6 +1411,7 @@
                     "contact",
                     "responsible",
                     "notes",
+                    "sortOrder",
                     "createdAt",
                     "updatedAt"
                 ],
@@ -1455,6 +1460,10 @@
                     "notes": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "sortOrder": {
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "createdAt": {
                         "type": "integer",
@@ -11521,6 +11530,12 @@
                                         "default": null,
                                         "description": "Category sort mode (name_asc, name_desc, custom)."
                                     },
+                                    "storeSort": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Store sort mode (name_asc, name_desc, custom)."
+                                    },
                                     "showAddedBy": {
                                         "type": "boolean",
                                         "nullable": true,
@@ -15734,6 +15749,13 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Free-form notes. Empty string clears it."
+                                    },
+                                    "sortOrder": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "New sort order."
                                     }
                                 }
                             }
@@ -15883,6 +15905,139 @@
                 "responses": {
                     "200": {
                         "description": "Store deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Success"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/pantry/api/houses/{houseId}/stores/reorder": {
+            "post": {
+                "operationId": "store-reorder",
+                "summary": "Batch reorder stores",
+                "tags": [
+                    "store"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "items": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Reorder entries.",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "id",
+                                                "sortOrder"
+                                            ],
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                },
+                                                "sortOrder": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "houseId",
+                        "in": "path",
+                        "description": "House id.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Stores reordered",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/api/prefs.ts
+++ b/src/api/prefs.ts
@@ -78,8 +78,9 @@ export async function setReuseExistingItems(
 export type PhotoSort = 'custom' | 'newest' | 'oldest' | 'description_asc' | 'description_desc'
 export type NoteSort = 'custom' | 'newest' | 'oldest' | 'title_asc' | 'title_desc'
 export type ChecklistItemSort =
-  'custom' | 'newest' | 'oldest' | 'name_asc' | 'name_desc' | 'category'
+  'custom' | 'newest' | 'oldest' | 'name_asc' | 'name_desc' | 'category' | 'store'
 export type CategorySort = 'name_asc' | 'name_desc' | 'custom'
+export type StoreSort = 'name_asc' | 'name_desc' | 'custom'
 export type ChecklistSort = 'name_asc' | 'name_desc' | 'custom'
 
 export interface PhotoSortPrefs {
@@ -104,6 +105,7 @@ export interface HousePrefs extends NotificationPrefs {
   checklistItemSort: ChecklistItemSort
   checklistSort: ChecklistSort
   categorySort: CategorySort
+  storeSort: StoreSort
   /** When true, show the avatar of the user who added each checklist item. */
   showAddedBy: boolean
   /** Last-used currency code (ISO 4217) for item prices in this house. */
@@ -118,6 +120,7 @@ const housePrefsDefaults: HousePrefs = {
   checklistItemSort: 'custom',
   checklistSort: 'custom',
   categorySort: 'name_asc',
+  storeSort: 'name_asc',
   showAddedBy: false,
   lastCurrency: 'USD',
   notifyPhoto: true,
@@ -218,6 +221,16 @@ export async function setCategorySort(
 ): Promise<{ sort: CategorySort }> {
   const p = await setHousePrefs(houseId, { categorySort: sort })
   return { sort: p.categorySort }
+}
+
+export async function getStoreSort(houseId: number): Promise<{ sort: StoreSort }> {
+  const p = await getHousePrefs(houseId)
+  return { sort: p.storeSort }
+}
+
+export async function setStoreSort(houseId: number, sort: StoreSort): Promise<{ sort: StoreSort }> {
+  const p = await setHousePrefs(houseId, { storeSort: sort })
+  return { sort: p.storeSort }
 }
 
 export async function getLastCurrency(houseId: number): Promise<string> {

--- a/src/api/stores.ts
+++ b/src/api/stores.ts
@@ -26,7 +26,7 @@ export async function createStore(houseId: number, input: StoreInput): Promise<S
 export async function updateStore(
   houseId: number,
   storeId: number,
-  patch: Partial<StoreInput>,
+  patch: Partial<StoreInput> & { sortOrder?: number },
 ): Promise<Store> {
   const resp = await ocs.patch<Store>(`/houses/${houseId}/stores/${storeId}`, patch)
   return resp.data
@@ -34,4 +34,11 @@ export async function updateStore(
 
 export async function deleteStore(houseId: number, storeId: number): Promise<void> {
   await ocs.delete(`/houses/${houseId}/stores/${storeId}`)
+}
+
+export async function reorderStores(
+  houseId: number,
+  items: { id: number; sortOrder: number }[],
+): Promise<void> {
+  await ocs.post(`/houses/${houseId}/stores/reorder`, { items })
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -108,6 +108,7 @@ export interface Store {
   contact: string | null
   responsible: string | null
   notes: string | null
+  sortOrder: number
   createdAt: number
   updatedAt: number
 }

--- a/src/components/ChecklistFilter/ChecklistFilter.test.ts
+++ b/src/components/ChecklistFilter/ChecklistFilter.test.ts
@@ -134,6 +134,7 @@ function makeStore(overrides: Partial<Store> = {}): Store {
     contact: null,
     responsible: null,
     notes: null,
+    sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,

--- a/src/components/ChecklistItemRow/ChecklistItemRow.test.ts
+++ b/src/components/ChecklistItemRow/ChecklistItemRow.test.ts
@@ -164,6 +164,7 @@ function makeStore(overrides: Partial<Store> = {}): Store {
     contact: null,
     responsible: null,
     notes: null,
+    sortOrder: 0,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,

--- a/src/components/ChecklistItemRow/ChecklistItemRow.vue
+++ b/src/components/ChecklistItemRow/ChecklistItemRow.vue
@@ -107,7 +107,7 @@
         {{ category.name }}
       </span>
       <button
-        v-for="store in stores"
+        v-for="store in hideStore ? [] : stores"
         :key="store.id"
         type="button"
         class="checklist-row__store"
@@ -232,6 +232,8 @@ const props = withDefaults(
     category: Category | null
     /** Hide the category chip (used when category headers already group rows). */
     hideCategory?: boolean
+    /** Hide the store chips (used when store headers already group rows). */
+    hideStore?: boolean
     /** Stores attached to this item, resolved to entities by the parent. */
     stores?: Store[]
     list?: Checklist | null
@@ -266,6 +268,7 @@ const props = withDefaults(
   }>(),
   {
     hideCategory: false,
+    hideStore: false,
     stores: () => [],
     list: null,
     reorderEnabled: false,

--- a/src/components/StoreManager/StoreManagerDialog.vue
+++ b/src/components/StoreManager/StoreManagerDialog.vue
@@ -6,6 +6,26 @@
     close-on-click-outside
     @update:open="$emit('update:open', $event)"
   >
+    <div v-if="!storeLoading && storeItems.length > 0" class="pantry-store-toolbar">
+      <NcActions :aria-label="strings.sortLabel" :title="strings.sortLabel" type="tertiary">
+        <template #icon>
+          <SortIcon :size="20" />
+        </template>
+        <NcActionButton
+          v-for="opt in sortOptions"
+          :key="opt.value"
+          :class="{ 'pantry-sort-active': currentSort === opt.value }"
+          @click="changeSort(opt.value)"
+        >
+          <template #icon>
+            <RadioboxMarkedIcon v-if="currentSort === opt.value" :size="20" />
+            <RadioboxBlankIcon v-else :size="20" />
+          </template>
+          {{ opt.label }}
+        </NcActionButton>
+      </NcActions>
+    </div>
+
     <div v-if="storeLoading" class="pantry-center">
       <NcLoadingIcon :size="28" />
     </div>
@@ -13,27 +33,59 @@
       <p v-if="storeItems.length === 0" class="pantry-store-hint">
         {{ strings.noStoresHint }}
       </p>
-      <ul v-else class="pantry-store-list">
-        <li v-for="store in storeItems" :key="store.id" class="pantry-store-list__item">
-          <button type="button" class="pantry-store-list__main" @click="viewStore(store)">
-            <span class="pantry-store-list__icon" :style="{ color: store.color }">
-              <component :is="storeIconComponent(store.icon)" :size="20" />
-            </span>
-            <span class="pantry-store-list__name">{{ store.name }}</span>
-          </button>
-          <div class="pantry-store-list__actions">
-            <NcButton variant="tertiary" :aria-label="strings.editStore" @click="startEdit(store)">
-              <template #icon><PencilIcon :size="18" /></template>
-            </NcButton>
-            <NcButton
-              variant="tertiary"
-              :aria-label="strings.deleteStore"
-              @click="confirmDelete(store)"
+      <ul v-else ref="listRef" class="pantry-store-list">
+        <template v-for="gi in gridItems" :key="gi.key">
+          <li
+            v-if="gi.type === 'placeholder'"
+            class="pantry-store-list__placeholder"
+            @dragover.prevent
+            @drop.prevent.stop="onPlaceholderDrop"
+          />
+          <li
+            v-else
+            :class="[
+              'pantry-store-list__item',
+              { 'pantry-store-list__item--dragging': draggingId === gi.store.id },
+            ]"
+            :data-drag-id="gi.store.id"
+            :draggable="isCustomSort ? 'true' : 'false'"
+            @dragstart="onDragStart($event, gi.store.id)"
+            @dragend="onDragEnd"
+            @dragover.prevent="onDragOver($event, gi.store.id)"
+            @drop.prevent.stop="commitReorder"
+          >
+            <span
+              v-if="isCustomSort"
+              class="pantry-store-list__handle"
+              :aria-label="strings.dragHandle"
+              :title="strings.dragHandle"
             >
-              <template #icon><DeleteIcon :size="18" /></template>
-            </NcButton>
-          </div>
-        </li>
+              <DragVerticalIcon :size="20" />
+            </span>
+            <button type="button" class="pantry-store-list__main" @click="viewStore(gi.store)">
+              <span class="pantry-store-list__icon" :style="{ color: gi.store.color }">
+                <component :is="storeIconComponent(gi.store.icon)" :size="20" />
+              </span>
+              <span class="pantry-store-list__name">{{ gi.store.name }}</span>
+            </button>
+            <div class="pantry-store-list__actions">
+              <NcButton
+                variant="tertiary"
+                :aria-label="strings.editStore"
+                @click="startEdit(gi.store)"
+              >
+                <template #icon><PencilIcon :size="18" /></template>
+              </NcButton>
+              <NcButton
+                variant="tertiary"
+                :aria-label="strings.deleteStore"
+                @click="confirmDelete(gi.store)"
+              >
+                <template #icon><DeleteIcon :size="18" /></template>
+              </NcButton>
+            </div>
+          </li>
+        </template>
       </ul>
     </template>
     <template #actions>
@@ -80,17 +132,26 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { t } from '@nextcloud/l10n'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import PlusIcon from '@icons/Plus.vue'
 import DeleteIcon from '@icons/Delete.vue'
 import PencilIcon from '@icons/Pencil.vue'
+import SortIcon from '@icons/Sort.vue'
+import RadioboxBlankIcon from '@icons/RadioboxBlank.vue'
+import RadioboxMarkedIcon from '@icons/RadioboxMarked.vue'
+import DragVerticalIcon from '@icons/DragVertical.vue'
 import type { Store } from '@/api/types'
 import type { StoreInput } from '@/api/stores'
+import type { StoreSort } from '@/api/prefs'
+import { getStoreSort, setStoreSort } from '@/api/prefs'
 import { useStores } from '@/composables/useStores'
+import { useTouchReorder } from '@/composables/useTouchReorder'
 import { storeIconComponent } from '@/components/StoreMultiPicker/storeIcons'
 import StoreFormDialog from './StoreFormDialog.vue'
 import StoreViewDialog from './StoreViewDialog.vue'
@@ -109,10 +170,33 @@ const stores = useStores(props.houseId)
 const storeItems = computed(() => stores.items.value)
 const storeLoading = computed(() => stores.loading.value)
 
+const currentSort = ref<StoreSort>('name_asc')
+const isCustomSort = computed(() => currentSort.value === 'custom')
+
+const sortOptions: { value: StoreSort; label: string }[] = [
+  { value: 'name_asc', label: t('pantry', 'Name A–Z') },
+  { value: 'name_desc', label: t('pantry', 'Name Z–A') },
+  { value: 'custom', label: t('pantry', 'Custom') },
+]
+
+async function loadSortPref() {
+  const prefs = await getStoreSort(props.houseId)
+  currentSort.value = prefs.sort
+  stores.setSortBy(prefs.sort)
+}
+
+async function changeSort(value: StoreSort) {
+  if (value === currentSort.value) return
+  currentSort.value = value
+  stores.setSortBy(value)
+  await setStoreSort(props.houseId, value)
+}
+
 watch(
   () => props.open,
   async (isOpen) => {
     if (isOpen) {
+      await loadSortPref()
       await stores.load()
     }
   },
@@ -128,6 +212,125 @@ watch(
     }
   },
   { immediate: true },
+)
+
+// -------- Drag & drop reorder --------
+
+type ListGridItem =
+  { type: 'store'; key: string; store: Store } | { type: 'placeholder'; key: string }
+
+const draggingId = ref<number | null>(null)
+const dropIndex = ref<number | null>(null)
+const listRef = ref<HTMLElement | null>(null)
+
+const gridItems = computed<ListGridItem[]>(() => {
+  const source = storeItems.value
+  if (!isCustomSort.value || draggingId.value === null || dropIndex.value === null) {
+    return source.map((s) => ({ type: 'store' as const, key: 's-' + s.id, store: s }))
+  }
+  const dragId = draggingId.value
+  const without = source.filter((s) => s.id !== dragId)
+  const out: ListGridItem[] = without.map((s) => ({
+    type: 'store' as const,
+    key: 's-' + s.id,
+    store: s,
+  }))
+  const clamped = Math.min(dropIndex.value, out.length)
+  out.splice(clamped, 0, { type: 'placeholder', key: 'drop-placeholder' })
+  return out
+})
+
+function onDragStart(e: DragEvent, id: number) {
+  if (!isCustomSort.value || !e.dataTransfer) return
+  draggingId.value = id
+  dropIndex.value = null
+  e.dataTransfer.effectAllowed = 'move'
+  // Some browsers refuse to start a drag without data — set anything.
+  e.dataTransfer.setData('text/plain', String(id))
+}
+
+function onDragEnd() {
+  draggingId.value = null
+  dropIndex.value = null
+}
+
+function computeDropIndex(hoveredId: number, clientY: number, target: HTMLElement | null) {
+  const dragId = draggingId.value
+  if (!dragId || dragId === hoveredId) return
+  const without = storeItems.value.filter((s) => s.id !== dragId)
+  const idx = without.findIndex((s) => s.id === hoveredId)
+  if (idx === -1) return
+  if (target) {
+    const rect = target.getBoundingClientRect()
+    const past = clientY > rect.top + rect.height / 2
+    dropIndex.value = past ? idx + 1 : idx
+  } else {
+    dropIndex.value = idx
+  }
+}
+
+function onDragOver(e: DragEvent, hoveredId: number) {
+  computeDropIndex(hoveredId, e.clientY, e.currentTarget as HTMLElement | null)
+}
+
+function onPlaceholderDrop() {
+  commitReorder()
+}
+
+async function commitReorder() {
+  const dragId = draggingId.value
+  const idx = dropIndex.value
+  draggingId.value = null
+  dropIndex.value = null
+  if (dragId === null || idx === null) return
+
+  const source = storeItems.value
+  const dragged = source.find((s) => s.id === dragId)
+  if (!dragged) return
+
+  const without = source.filter((s) => s.id !== dragId)
+  const clamped = Math.min(idx, without.length)
+  const reordered = [...without]
+  reordered.splice(clamped, 0, dragged)
+  const entries = reordered.map((s, n) => ({ id: s.id, sortOrder: n }))
+  await stores.reorder(entries)
+}
+
+function bindDragListeners(el: HTMLElement | null) {
+  if (!el) return
+  el.addEventListener('dragend', onDragEnd, true)
+}
+function unbindDragListeners(el: HTMLElement | null) {
+  if (!el) return
+  el.removeEventListener('dragend', onDragEnd, true)
+}
+
+watch(listRef, (newEl, oldEl) => {
+  unbindDragListeners(oldEl ?? null)
+  bindDragListeners(newEl ?? null)
+})
+onBeforeUnmount(() => {
+  unbindDragListeners(listRef.value)
+})
+
+useTouchReorder(
+  listRef,
+  {
+    onDragStart: (id) => {
+      draggingId.value = id
+      dropIndex.value = null
+    },
+    onReorderOver(hoveredId, _clientX, clientY) {
+      const el = listRef.value?.querySelector<HTMLElement>(`[data-drag-id="${hoveredId}"]`) ?? null
+      computeDropIndex(hoveredId, clientY, el)
+    },
+    onDrop: commitReorder,
+    onCancel() {
+      draggingId.value = null
+      dropIndex.value = null
+    },
+  },
+  isCustomSort,
 )
 
 // -------- Form state --------
@@ -217,6 +420,8 @@ const strings = {
   deleteStore: t('pantry', 'Delete'),
   // TRANSLATORS: Noun, a shop where items are bought. Dialog title.
   deleteStoreTitle: t('pantry', 'Delete store'),
+  sortLabel: t('pantry', 'Sort order'),
+  dragHandle: t('pantry', 'Drag to reorder'),
 }
 </script>
 
@@ -225,6 +430,12 @@ const strings = {
   display: flex;
   justify-content: center;
   padding: 1rem;
+}
+
+.pantry-store-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.25rem;
 }
 
 .pantry-store-hint {
@@ -243,6 +454,19 @@ const strings = {
     gap: 0.5rem;
     padding: 6px 0;
     border-bottom: 1px solid var(--color-border);
+
+    &--dragging {
+      opacity: 0.4;
+    }
+  }
+
+  &__handle {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    cursor: grab;
+    color: var(--color-text-maxcontrast);
+    touch-action: none;
   }
 
   &__main {
@@ -285,5 +509,18 @@ const strings = {
     gap: 0;
     flex-shrink: 0;
   }
+
+  &__placeholder {
+    min-height: 40px;
+    border: 3px dashed var(--color-primary-element);
+    border-radius: var(--border-radius, 8px);
+    background: rgba(var(--color-primary-element-rgb, 0, 120, 212), 0.08);
+    list-style: none;
+    margin: 4px 0;
+  }
+}
+
+.pantry-sort-active {
+  font-weight: 600;
 }
 </style>

--- a/src/composables/useStores.ts
+++ b/src/composables/useStores.ts
@@ -2,12 +2,26 @@ import { ref } from 'vue'
 import * as api from '@/api/stores'
 import type { StoreInput } from '@/api/stores'
 import type { Store } from '@/api/types'
+import type { StoreSort } from '@/api/prefs'
+import { getStoreSort } from '@/api/prefs'
 
 // Cache per house id so multiple components sharing the same house stay in sync.
 const cache = new Map<number, ReturnType<typeof build>>()
 
-function sortItems(items: Store[]): Store[] {
-  return [...items].sort((a, b) => a.name.localeCompare(b.name))
+function sortItems(items: Store[], sortBy: StoreSort): Store[] {
+  const next = [...items]
+  switch (sortBy) {
+    case 'name_desc':
+      next.sort((a, b) => b.name.localeCompare(a.name))
+      break
+    case 'custom':
+      next.sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name))
+      break
+    default:
+      next.sort((a, b) => a.name.localeCompare(b.name))
+      break
+  }
+  return next
 }
 
 function build(houseId: number) {
@@ -15,14 +29,19 @@ function build(houseId: number) {
   const loading = ref(false)
   const error = ref<string | null>(null)
   const loaded = ref(false)
+  const sortBy = ref<StoreSort>('name_asc')
 
   async function load(force = false): Promise<void> {
     if (loaded.value && !force) return
     loading.value = true
     error.value = null
     try {
-      const fetched = await api.listStores(houseId)
-      items.value = sortItems(fetched)
+      const [fetched, pref] = await Promise.all([
+        api.listStores(houseId),
+        getStoreSort(houseId).catch(() => ({ sort: sortBy.value })),
+      ])
+      sortBy.value = pref.sort
+      items.value = sortItems(fetched, sortBy.value)
       loaded.value = true
     } catch (e) {
       error.value = (e as Error).message
@@ -31,21 +50,38 @@ function build(houseId: number) {
     }
   }
 
+  function setSortBy(value: StoreSort): void {
+    sortBy.value = value
+    items.value = sortItems(items.value, value)
+  }
+
   async function create(input: StoreInput): Promise<Store> {
     const created = await api.createStore(houseId, input)
-    items.value = sortItems([...items.value, created])
+    items.value = sortItems([...items.value, created], sortBy.value)
     return created
   }
 
   async function update(id: number, patch: Parameters<typeof api.updateStore>[2]): Promise<Store> {
     const updated = await api.updateStore(houseId, id, patch)
-    items.value = sortItems(items.value.map((s) => (s.id === id ? updated : s)))
+    items.value = sortItems(
+      items.value.map((s) => (s.id === id ? updated : s)),
+      sortBy.value,
+    )
     return updated
   }
 
   async function remove(id: number): Promise<void> {
     await api.deleteStore(houseId, id)
     items.value = items.value.filter((s) => s.id !== id)
+  }
+
+  async function reorder(entries: { id: number; sortOrder: number }[]): Promise<void> {
+    // Apply optimistically so there's no visual jump while the API call is in flight.
+    const map = new Map(entries.map((e) => [e.id, e.sortOrder]))
+    items.value = items.value
+      .map((s) => (map.has(s.id) ? { ...s, sortOrder: map.get(s.id)! } : s))
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name))
+    await api.reorderStores(houseId, entries)
   }
 
   function findById(id: number | null | undefined): Store | undefined {
@@ -58,10 +94,13 @@ function build(houseId: number) {
     loading,
     error,
     loaded,
+    sortBy,
     load,
+    setSortBy,
     create,
     update,
     remove,
+    reorder,
     findById,
   }
 }

--- a/src/views/ChecklistDetail.vue
+++ b/src/views/ChecklistDetail.vue
@@ -206,12 +206,23 @@
                 {{ gi.category?.name ?? strings.noCategory }}
               </span>
             </li>
+            <li
+              v-else-if="gi.type === 'store-header'"
+              class="pantry-detail__category-header"
+              :style="gi.store ? { color: gi.store.color } : undefined"
+            >
+              <component :is="storeIconComponent(gi.store?.icon)" :size="18" />
+              <span class="pantry-detail__category-header-name">
+                {{ gi.store?.name ?? strings.noStore }}
+              </span>
+            </li>
             <ChecklistItemRow
               v-else
               :item="gi.item"
               :category="categoryFor(gi.item.categoryId)"
               :stores="storesFor(gi.item.storeIds)"
               :hide-category="showCategoryHeaders"
+              :hide-store="showStoreHeaders"
               :list="isMeta ? listFor(gi.item.listId) : null"
               :list-writable="isMeta ? listWritable(listFor(gi.item.listId)) : writableHere"
               :house-id="houseIdNum"
@@ -261,12 +272,23 @@
                   {{ gi.category?.name ?? strings.noCategory }}
                 </span>
               </li>
+              <li
+                v-else-if="gi.type === 'store-header'"
+                class="pantry-detail__category-header"
+                :style="gi.store ? { color: gi.store.color } : undefined"
+              >
+                <component :is="storeIconComponent(gi.store?.icon)" :size="18" />
+                <span class="pantry-detail__category-header-name">
+                  {{ gi.store?.name ?? strings.noStore }}
+                </span>
+              </li>
               <ChecklistItemRow
                 v-else
                 :item="gi.item"
                 :category="categoryFor(gi.item.categoryId)"
                 :stores="storesFor(gi.item.storeIds)"
                 :hide-category="showCategoryHeaders"
+                :hide-store="showStoreHeaders"
                 :list="isMeta ? listFor(gi.item.listId) : null"
                 :list-writable="isMeta ? listWritable(listFor(gi.item.listId)) : writableHere"
                 :house-id="houseIdNum"
@@ -598,6 +620,7 @@ import { MarkdownExportDialog } from '@/components/MarkdownExportDialog'
 import { MarkdownImportDialog } from '@/components/MarkdownImportDialog'
 import CategoryPicker, { categoryIconComponent } from '@/components/CategoryPicker'
 import StoreMultiPicker from '@/components/StoreMultiPicker'
+import { storeIconComponent } from '@/components/StoreMultiPicker/storeIcons'
 import {
   checklistIconComponent,
   ChecklistFormDialog,
@@ -779,6 +802,8 @@ const allItemSortOptions: { value: ChecklistItemSort; label: string }[] = [
   { value: 'name_asc', label: t('pantry', 'Name A\u2013Z') },
   { value: 'name_desc', label: t('pantry', 'Name Z\u2013A') },
   { value: 'category', label: t('pantry', 'Category') },
+  // TRANSLATORS: Noun, a shop where items are bought. Sort/group option.
+  { value: 'store', label: t('pantry', 'Store') },
   { value: 'custom', label: t('pantry', 'Custom') },
 ]
 
@@ -822,6 +847,9 @@ const { can } = useCurrentHouse()
 const showAddedBy = computed(() => useShowAddedBy(houseIdNum.value).showAddedBy.value)
 // Sorting by category always groups items under category headers.
 const showCategoryHeaders = computed(() => currentSort.value === 'category')
+// Sorting by store groups items under store headers; an item in several stores
+// is duplicated under each (see withStoreGroups).
+const showStoreHeaders = computed(() => currentSort.value === 'store')
 
 onMounted(async () => {
   await loadSortPref()
@@ -1030,6 +1058,7 @@ type ListGridItem =
   | { type: 'item'; key: string; item: ChecklistItem }
   | { type: 'placeholder'; key: string }
   | { type: 'header'; key: string; category: Category | null }
+  | { type: 'store-header'; key: string; store: Store | null }
 
 type Partition = 'unchecked' | 'checked'
 
@@ -1062,8 +1091,52 @@ function withCategoryHeaders(items: ListGridItem[]): ListGridItem[] {
   return out
 }
 
+// Groups a partition's items under store headers, following the store order in
+// `stores.items`. An item attached to several stores appears once under each;
+// items with no (known) store fall under a trailing "No store" header. Every
+// rendered copy shares the underlying item id, so toggling one toggles all.
+function withStoreGroups(items: ChecklistItem[], p: Partition): ListGridItem[] {
+  const orderedStores = stores.items.value
+  const storeIdSet = new Set(orderedStores.map((s) => s.id))
+  const buckets = new Map<number, ChecklistItem[]>()
+  const noStore: ChecklistItem[] = []
+  for (const it of items) {
+    const ids = (it.storeIds ?? []).filter((id) => storeIdSet.has(id))
+    if (ids.length === 0) {
+      noStore.push(it)
+      continue
+    }
+    for (const id of ids) {
+      const arr = buckets.get(id)
+      if (arr) arr.push(it)
+      else buckets.set(id, [it])
+    }
+  }
+  const byName = (a: ChecklistItem, b: ChecklistItem) => a.name.localeCompare(b.name)
+  const out: ListGridItem[] = []
+  for (const store of orderedStores) {
+    const groupItems = buckets.get(store.id)
+    if (!groupItems || groupItems.length === 0) continue
+    out.push({ type: 'store-header', key: `sh-${p}-${store.id}`, store })
+    for (const it of [...groupItems].sort(byName)) {
+      out.push({ type: 'item', key: `i-${p}-${store.id}-${it.id}`, item: it })
+    }
+  }
+  if (noStore.length > 0) {
+    out.push({ type: 'store-header', key: `sh-${p}-none`, store: null })
+    for (const it of [...noStore].sort(byName)) {
+      out.push({ type: 'item', key: `i-${p}-none-${it.id}`, item: it })
+    }
+  }
+  return out
+}
+
 function buildGridItems(p: Partition): ListGridItem[] {
   const source = partitionItems(p)
+  // Store grouping (never active alongside custom-sort drag) takes over first.
+  if (showStoreHeaders.value) {
+    return withStoreGroups(source, p)
+  }
   const dragId = draggingItemId.value
   if (
     !isCustomSort.value ||
@@ -2018,6 +2091,7 @@ const strings = {
   // TRANSLATORS: Section heading above the completed (checked-off) items.
   doneTitle: t('pantry', 'Done'),
   noCategory: t('pantry', 'No category'),
+  noStore: t('pantry', 'No store'),
   manageCategories: t('pantry', 'Manage categories'),
   // TRANSLATORS: Noun (plural), shops where items are bought. Toolbar action opening the store manager.
   manageStores: t('pantry', 'Manage stores'),

--- a/src/views/shopping/ShoppingStartView.vue
+++ b/src/views/shopping/ShoppingStartView.vue
@@ -170,7 +170,7 @@ const { houseId } = useCurrentHouse()
 const houseIdNum = computed(() => houseId.value ?? 0)
 
 const { lists, load: loadLists } = useChecklists(houseIdNum.value)
-const { load: loadStores, findById: findStore } = useStores(houseIdNum.value)
+const { items: storeCatalog, load: loadStores, findById: findStore } = useStores(houseIdNum.value)
 const { load: loadHouses, findById: findHouse } = useHouses()
 
 const loading = ref(true)
@@ -196,7 +196,9 @@ const allSelected = computed(
 )
 
 // Stores worth planning a route to: those with at least one un-done item on a
-// selected list. Sorted by name for a stable default order.
+// selected list. Ordered by the house's own store order (the storeSort pref —
+// name or custom) so the default route matches how stores are arranged
+// everywhere else; the shopper can then reorder them for this trip only.
 const availableStoreIds = computed<number[]>(() => {
   const selected = new Set(selectedListIds.value)
   const ids = new Set<number>()
@@ -204,7 +206,10 @@ const availableStoreIds = computed<number[]>(() => {
     if (item.done || !selected.has(item.listId)) continue
     for (const storeId of item.storeIds) ids.add(storeId)
   }
-  return [...ids].sort((a, b) => (storeName(a) || '').localeCompare(storeName(b) || ''))
+  const rank = new Map(storeCatalog.value.map((s, i) => [s.id, i]))
+  return [...ids].sort(
+    (a, b) => (rank.get(a) ?? Number.MAX_SAFE_INTEGER) - (rank.get(b) ?? Number.MAX_SAFE_INTEGER),
+  )
 })
 
 // The user's route: the available stores in a chosen order, each on/off.

--- a/tests/unit/Service/StoreServiceTest.php
+++ b/tests/unit/Service/StoreServiceTest.php
@@ -48,7 +48,7 @@ class StoreServiceTest extends TestCase {
 		$stores = [$this->makeStore()];
 		$this->mapper->expects($this->once())
 			->method('findByHouse')
-			->with(1)
+			->with(1, 'name_asc')
 			->willReturn($stores);
 
 		$this->assertSame($stores, $this->svc->listForHouse(1));
@@ -237,5 +237,68 @@ class StoreServiceTest extends TestCase {
 		$this->mapper->method('findById')->willThrowException(new DoesNotExistException(''));
 		$this->expectException(NotFoundException::class);
 		$this->svc->get(123);
+	}
+
+	public function testListForHousePassesSortByToMapper(): void {
+		$stores = [$this->makeStore()];
+		$this->mapper->expects($this->once())
+			->method('findByHouse')
+			->with(1, 'custom')
+			->willReturn($stores);
+
+		$this->assertSame($stores, $this->svc->listForHouse(1, 'custom'));
+	}
+
+	public function testCreateAppendsAfterHighestSortOrder(): void {
+		$this->mapper->method('findByHouseAndName')->willReturn(null);
+		$this->mapper->method('findMaxSortOrder')->with(1)->willReturn(4);
+		$this->mapper->method('insert')->willReturnArgument(0);
+
+		$created = $this->svc->create(1, 'Aisle 8', 'store', '#e11d48');
+
+		$this->assertSame(5, $created->getSortOrder());
+	}
+
+	public function testCreateInEmptyHouseStartsAtZero(): void {
+		$this->mapper->method('findByHouseAndName')->willReturn(null);
+		$this->mapper->method('findMaxSortOrder')->with(1)->willReturn(-1);
+		$this->mapper->method('insert')->willReturnArgument(0);
+
+		$created = $this->svc->create(1, 'Produce', 'store', '#22c55e');
+
+		$this->assertSame(0, $created->getSortOrder());
+	}
+
+	public function testReorderUpdatesEachInHouse(): void {
+		$s1 = $this->makeStore(['id' => 1, 'houseId' => 1]);
+		$s2 = $this->makeStore(['id' => 2, 'houseId' => 1]);
+		$foreign = $this->makeStore(['id' => 3, 'houseId' => 99]);
+
+		$this->mapper->method('findById')->willReturnCallback(function (int $id) use ($s1, $s2, $foreign) {
+			return match ($id) {
+				1 => $s1,
+				2 => $s2,
+				3 => $foreign,
+				default => throw new DoesNotExistException(''),
+			};
+		});
+
+		$this->mapper->expects($this->exactly(2))->method('update');
+
+		$this->svc->reorder(1, [
+			['id' => 2, 'sortOrder' => 0],
+			['id' => 1, 'sortOrder' => 1],
+			['id' => 3, 'sortOrder' => 2], // wrong house, ignored
+		]);
+
+		$this->assertSame(1, $s1->getSortOrder());
+		$this->assertSame(0, $s2->getSortOrder());
+	}
+
+	public function testReorderSkipsMissingId(): void {
+		$this->mapper->method('findById')->willThrowException(new DoesNotExistException(''));
+		$this->mapper->expects($this->never())->method('update');
+
+		$this->svc->reorder(1, [['id' => 999, 'sortOrder' => 0]]);
 	}
 }


### PR DESCRIPTION
## Summary

Adds **sort and group checklist items by store**, mirroring the existing category feature, plus **manual store reordering** and a store-order-aware Shopping Mode.

### Checklist
- New `Store` checklist sort mode. Selecting it groups items under sticky store headers (reusing the category-header styling) and hides the per-item store chips.
- **Multi-store items are duplicated** under each store they belong to, with a trailing **No store** group. Every rendered copy shares the underlying item id, so checking one copy marks the item done everywhere.

### Stores
- Stores gained a `sortOrder` column (migration `Version22`) and a `storeSort` pref (`name_asc` / `name_desc` / `custom`, default `name_asc`).
- The **Manage stores** dialog now has the same sort menu + drag-drop reorder as the category manager (drag only in Custom mode), backed by a new `POST /houses/{id}/stores/reorder` endpoint.

### Shopping Mode
- The session-start screen now seeds its store route from the house's store order (name or custom) instead of a hardcoded name sort. The shopper can still reorder stores **for that trip only**.

### Capability
- Advertises the `store-sort` feature flag so the Flutter companion app can gate its parity implementation.

## Verification
- `pnpm typecheck` clean; **480** frontend unit tests pass; **307** PHP tests pass (incl. new `StoreService` reorder + append-`sortOrder` tests).
- Migration `Version22` applies cleanly; schema at latest.
- Live OCS check: `sortOrder` serializes, new stores append at `max+1`, `storeSort=custom` persists, and `POST /stores/reorder` reorders the list.

## Notes
- Grouping/duplication is computed client-side; the item-list endpoints are unchanged.
- Within a store group, items sort by name (A–Z)

Closes #203 
